### PR TITLE
Bump to 4.1.13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,4 @@ group :development, :test do
   gem 'railroady'
 end
 
-gem 'simplecov', :require => false, :group => :test
-
 gem 'foundation-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'resque_mailer'
 gem 'factory_girl_rails'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '4.1.0'
+gem 'rails', '4.1.13'
 # Use sqlite3 as the database for Active Record
 gem 'pg'
 # Use SCSS for stylesheets
@@ -76,5 +76,7 @@ group :development, :test do
   gem 'capybara'
   gem 'railroady'
 end
+
+gem 'simplecov', :require => false, :group => :test
 
 gem 'foundation-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.1.0)
-      actionpack (= 4.1.0)
-      actionview (= 4.1.0)
+    actionmailer (4.1.13)
+      actionpack (= 4.1.13)
+      actionview (= 4.1.13)
       mail (~> 2.5.4)
-    actionpack (4.1.0)
-      actionview (= 4.1.0)
-      activesupport (= 4.1.0)
+    actionpack (4.1.13)
+      actionview (= 4.1.13)
+      activesupport (= 4.1.13)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    actionview (4.1.0)
-      activesupport (= 4.1.0)
+    actionview (4.1.13)
+      activesupport (= 4.1.13)
       builder (~> 3.1)
       erubis (~> 2.7.0)
-    activemodel (4.1.0)
-      activesupport (= 4.1.0)
+    activemodel (4.1.13)
+      activesupport (= 4.1.13)
       builder (~> 3.1)
-    activerecord (4.1.0)
-      activemodel (= 4.1.0)
-      activesupport (= 4.1.0)
+    activerecord (4.1.13)
+      activemodel (= 4.1.13)
+      activesupport (= 4.1.13)
       arel (~> 5.0.0)
-    activesupport (4.1.0)
+    activesupport (4.1.13)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -87,6 +87,7 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    docile (1.1.5)
     erubis (2.7.0)
     execjs (2.5.2)
     extlib (0.9.16)
@@ -177,24 +178,24 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     railroady (1.3.0)
-    rails (4.1.0)
-      actionmailer (= 4.1.0)
-      actionpack (= 4.1.0)
-      actionview (= 4.1.0)
-      activemodel (= 4.1.0)
-      activerecord (= 4.1.0)
-      activesupport (= 4.1.0)
+    rails (4.1.13)
+      actionmailer (= 4.1.13)
+      actionpack (= 4.1.13)
+      actionview (= 4.1.13)
+      activemodel (= 4.1.13)
+      activerecord (= 4.1.13)
+      activesupport (= 4.1.13)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.1.0)
+      railties (= 4.1.13)
       sprockets-rails (~> 2.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
     rails_serve_static_assets (0.0.4)
     rails_stdout_logging (0.0.3)
-    railties (4.1.0)
-      actionpack (= 4.1.0)
-      activesupport (= 4.1.0)
+    railties (4.1.13)
+      actionpack (= 4.1.13)
+      activesupport (= 4.1.13)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
@@ -257,6 +258,11 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.0)
       multi_json (~> 1.10)
+    simplecov (0.9.1)
+      docile (~> 1.1.0)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -315,7 +321,7 @@ DEPENDENCIES
   pg
   protected_attributes
   railroady
-  rails (= 4.1.0)
+  rails (= 4.1.13)
   rails_12factor
   resque
   resque-scheduler
@@ -324,10 +330,8 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0.1)
   sdoc (~> 0.4.0)
+  simplecov
   spring
   turbolinks
   uglifier (>= 1.3.0)
   underscore-rails
-
-BUNDLED WITH
-   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,6 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
-    docile (1.1.5)
     erubis (2.7.0)
     execjs (2.5.2)
     extlib (0.9.16)
@@ -258,11 +257,6 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.0)
       multi_json (~> 1.10)
-    simplecov (0.9.1)
-      docile (~> 1.1.0)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.8.0)
-    simplecov-html (0.8.0)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -330,7 +324,6 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0.1)
   sdoc (~> 0.4.0)
-  simplecov
   spring
   turbolinks
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Bumps rails to 4.1.13 which should take care of some vulnerabilities in earlier versions of rails 4.1.

Brakeman results afterward:

```
+SECURITY WARNINGS+

+------------+----------------------+--------+----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------->>
| Confidence | Class                | Method | Warning Type         | Message                                                                                                                                                           >>
+------------+----------------------+--------+----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------->>
| Medium     | CategoriesController | show   | Cross Site Scripting | Unsafe model attribute in link_to href near line 22: link_to(User.where(:id => +Category.find(params[:id])+.userid).first.name, ("/profile?userid=" + +Category.fi>>
| Medium     | MoodsController      | show   | Cross Site Scripting | Unsafe model attribute in link_to href near line 22: link_to(User.where(:id => +Mood.find(params[:id])+.userid).first.name, ("/profile?userid=" + +Mood.find(param>>
| Medium     | StrategiesController | show   | Cross Site Scripting | Unsafe model attribute in link_to href near line 20: link_to(User.where(:id => +Strategy.find(params[:id])+.userid).first.name, ("/profile?userid=" + +Strategy.fi>>
| Medium     | TriggersController   | show   | Cross Site Scripting | Unsafe model attribute in link_to href near line 20: link_to(User.where(:id => +Trigger.find(params[:id])+.userid).first.name, ("/profile?userid=" + +Trigger.find>>
+------------+----------------------+--------+----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------->>



Model Warnings:

+------------+---------+-----------------+-----------------------------------------------------------------------------+
| Confidence | Model   | Warning Type    | Message                                                                     |
+------------+---------+-----------------+-----------------------------------------------------------------------------+
| Weak       | Support | Mass Assignment | Potentially dangerous attribute available for mass assignment: :support_ids |
+------------+---------+-----------------+-----------------------------------------------------------------------------+
```

