### PR TITLE
removed deprecated @page_title variables from groups controller

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,7 +6,6 @@ class GroupsController < ApplicationController
   # GET /groups.json
   def index
     @groups = GroupMember.where(userid: current_user.id).all
-    @page_title = "Groups"
     accepted_allies = get_accepted_allies(current_user.id)
     @page_new = new_group_path
 
@@ -23,7 +22,6 @@ class GroupsController < ApplicationController
   # GET /groups/1.json
   def show
   	@group = Group.find(params[:id])
-  	@page_title = @group.name
     @page_new = new_meeting_path + '/?groupid=' + @group.id.to_s
   	@meetings = Meeting.where(groupid: @group.id).order('created_at DESC')
   	@group_leaders = GroupMember.where(groupid: @group.id, leader: true).all
@@ -32,12 +30,10 @@ class GroupsController < ApplicationController
   # GET /groups/new
   def new
     @group = Group.new
-    @page_title = "New Group"
   end
 
   # GET /groups/1/edit
   def edit
-    @page_title = "Edit " + @group.name
     @group_members = GroupMember.where(groupid: @group.id).all
   end
 
@@ -45,7 +41,6 @@ class GroupsController < ApplicationController
   # POST /groups.json
   def create
     @group = Group.new(group_params)
-    @page_title = "New Group"
     respond_to do |format|
       if @group.save
         group_member = GroupMember.new(groupid: @group.id, userid: current_user.id, leader: true)
@@ -63,7 +58,6 @@ class GroupsController < ApplicationController
   # PATCH/PUT /groups/1
   # PATCH/PUT /groups/1.json
   def update
-    @page_title = "Edit " + @group.name
     respond_to do |format|
       if @group.update(group_params)
         error = false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150616014804) do
+ActiveRecord::Schema.define(version: 20150506005730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Hi! Thanks for sharing ifme with the thoughtbot open source group! I enjoyed looking through your project, but did encounter difficulties contributing to the ifme project. In particular, I was confused why the forking the current repo generated javascript-related UI issues (unable to access drop-down tabs when navigating within the website; only works on page load), which did not happen on the live production site. Additionally, not using active record to do model associations makes it harder to understand how the codebase works. However, I was able to start making a small contribution to the groups controller be deleting the usage of the unnecessary/un-used instance variable, @page_title