### PR TITLE
Cleanup to config/database.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,51 +113,7 @@ rvm gemset pristine
 
 On Windows, you may encounter an error like `SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed`.  If this happens, download the [CURL CA bundle](http://curl.haxx.se/ca/cacert.pem) and set the environment variable `SSL_CERT_FILE` to point to it.
 
-### Setting Up Postgres
-
-Time to set up a Postgres user!
-
-```
-sudo su - postgres
-```
-
-```
-createuser -s -r ifme_app
-````
-
-In `pg_hba.conf`, make sure the value for `auth-method` in the `ifme_app` database is `trust`. This is because no password is being used for the local development and test databases, as seen in `database.yml`. Refer to this [guide](http://www.postgresql.org/docs/8.2/static/auth-pg-hba-conf.html) as a reference.
-
-To find the path of `pg_hba.conf` run the following commands.
-
-```
-psql
-```
-
-```
-SHOW hba_file;
-```
-
-If you're using Ubuntu, your `pg_hba.conf` file is probably in `/etc/postgresql/9.*/main/`
-
-Your final `pg_hba.conf` file should look something like this.
-
-```
-# TYPE  DATABASE          USER            ADDRESS                 METHOD
-
-# ifme_app
-host    ifme_development  ifme_app        127.0.0.1/32            trust
-
-# "local" is for Unix domain socket connections only
-local   all               all                                     peer
-# IPv4 local connections:
-host    all               all             127.0.0.1/32            md5
-# IPv6 local connections:
-host    all               all             ::1/128                 md5
-```
-
 ### Running the App Locally
-
-After exiting from Postgres by typing in `exit` in the terminal, run the following commands.
 
 ```
 bin/rake db:create db:migrate

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,11 +1,8 @@
-
 development:
   adapter: postgresql
   encoding: unicode
   host: localhost
   database: ifme_development
-  username: ifme_app
-  password:
   allow_concurrency: true
   pool: 5
   min_messages: warning
@@ -15,8 +12,6 @@ test:
   encoding: unicode
   host: localhost
   database: ifme_test
-  username: ifme_app
-  password:
   allow_concurrency: true
   pool: 5
   min_messages: error

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,4 @@
-development:
+development: &default
   adapter: postgresql
   encoding: unicode
   host: localhost
@@ -8,12 +8,8 @@ development:
   min_messages: warning
 
 test:
-  adapter: postgresql
-  encoding: unicode
-  host: localhost
+  <<: *default
   database: ifme_test
-  allow_concurrency: true
-  pool: 5
   min_messages: error
 
 production:


### PR DESCRIPTION
- Remove username and password specification from config/database.yml
- Remove now no longer necessary PostgreSQL document from README.md
- DRY up some of the configuration between the developement and test
environments.

Tested that the user specification wasn't necessary by doing the
following on a new fork of the project:

```bash
$ bundle install
$ # edit config/database.yml to remove username and password
$ bin/rake db:create:all db:migrate
$ bin/rake # all tests pass
$ bin/rails server # server runs successfully
```
