### PR TITLE
Fixtextarea

### DIFF
--- a/app/assets/javascripts/ckeditor/reinit.js
+++ b/app/assets/javascripts/ckeditor/reinit.js
@@ -1,0 +1,5 @@
+$(document).bind('page:change', function() {
+  $('.ckeditor').each(function() {
+    CKEDITOR.replace($(this).attr('id'));
+  });
+});

--- a/app/views/strategies/_form.html.erb
+++ b/app/views/strategies/_form.html.erb
@@ -61,7 +61,7 @@
   <div class="table_cell vertical_align_top">
     <div class="field">
       <div class="label"><%= f.label t('.describe') %></div>
-      <%= f.cktext_area :description, class: 'no_title special_textarea' %>
+      <%= f.cktext_area :description, class: 'no_title special_textarea ckeditor' %>
     </div>
   </div>
 

--- a/app/views/triggers/_form.html.erb
+++ b/app/views/triggers/_form.html.erb
@@ -109,13 +109,13 @@
       <div class="label">
         <%= f.label t('.describe') %>
       </div>
-      <%= f.cktext_area :why, class: 'no_title special_textarea' %>
+      <%= f.cktext_area :why, class: 'no_title special_textarea ckeditor' %>
     </div>
     <div class="field">
       <div class="label">
         <%= f.label t('.desired') %>
       </div>
-      <%= f.cktext_area :fix, class: 'no_title special_textarea' %>
+      <%= f.cktext_area :fix, class: 'no_title special_textarea ckeditor' %>
     </div>
   </div>
 


### PR DESCRIPTION
Hi! There was a bug with the ckeditor. Basically, when the page loads, the ckeditor didn't show up, the normal bootstrap text area showed up -- however, if you refresh it, the ckeditor would load. I was able to figure out that turbolinks was disrupting the javascript on the page, so thats why the ckeditor was only showing up on refresh. Originally, I wanted to remove all the turbolinks, but since I'm not familiar with the app, I don't know what else it would disrupt. I ended up adding a new JS page in the ckeditor file, which somewhat overrides the turbolinks for the added class. I also added ckeditor as a class to the textarea tags. 