### PR TITLE
Fix textarea, not displaying 100% on small screens

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -465,6 +465,10 @@ label {
 	display: inherit;
 	margin-bottom: 20px;
 }
+textarea {
+	width: 50%;
+	height: 100px;
+}
 
 input,
 textarea,
@@ -499,10 +503,6 @@ input[type="radio"] {
 	margin-right: 0px;
 }
 
-textarea {
-	width: 50%;
-	height: 100px;
-}
 
 input[type="submit"] {
 	border: 1px solid $container-color;


### PR DESCRIPTION
Hey Julia, 
I fixed a UI bug where the textarea was not displaying 100% for screens sizes that are < 1020px. The reason why, was because the css rule to make textarea width 50% was below the min-width media query. I move the rule above the query and it seems to fix the issue.

I added some screenshots, so you can see what I was talking about.   

After the fix.
![screen shot 2016-04-30 at 1 47 23 pm](https://cloud.githubusercontent.com/assets/1664019/14937635/efa7d32c-0edb-11e6-871b-89e82933a4fd.png)


![screen shot 2016-04-30 at 2 02 00 pm](https://cloud.githubusercontent.com/assets/1664019/14937648/3b754884-0edc-11e6-8968-7e349cdd450b.png)

![screen shot 2016-04-30 at 2 06 43 pm](https://cloud.githubusercontent.com/assets/1664019/14937668/d83dea36-0edc-11e6-95c5-2a2da6690143.png)

Befor the fix.
![screen shot 2016-04-30 at 1 49 17 pm](https://cloud.githubusercontent.com/assets/1664019/14937631/c0582bb2-0edb-11e6-8ced-6db189bde27e.png)

I could also change the css to have a max-width just for mobile sized screens if you want the inputs not to display 100% at 1020px and maybe have it change at a smaller screen size like 620px. I was not total sure if that is important or not. Now with the fix, I think it looks pretty good.


