### PR TITLE
Broken unit test error controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'chronic'
 
 group :development, :test do
   gem "byebug"
-  gem "rspec-rails"
+  gem "rspec-rails", '~> 3.4'
   gem 'rspec-collection_matchers'
   gem 'capybara'
   gem 'railroady'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,19 +281,23 @@ GEM
     retriable (2.1.0)
     rspec-collection_matchers (1.1.2)
       rspec-expectations (>= 2.99.0.beta1)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.4)
-    rspec-rails (2.99.0)
-      actionpack (>= 3.0)
-      activemodel (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-collection_matchers
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-rails (3.4.2)
+      actionpack (>= 3.0, < 4.3)
+      activesupport (>= 3.0, < 4.3)
+      railties (>= 3.0, < 4.3)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     ruby-graphviz (1.2.2)
     rufus-scheduler (3.2.0)
     sass (3.4.22)
@@ -383,7 +387,7 @@ DEPENDENCIES
   resque-scheduler
   resque_mailer
   rspec-collection_matchers
-  rspec-rails
+  rspec-rails (~> 3.4)
   ruby-graphviz
   sass-rails (~> 5.0.1)
   sdoc (~> 0.4.0)
@@ -393,5 +397,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   underscore-rails
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.1


### PR DESCRIPTION
Update rspec-rails to 3.4 (Gemfile and .lock) to have access to matchers.