### PR TITLE
Fix rspec deprecation for requiring rspec/autorun

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
 require 'rspec/collection_matchers'
 
 # Requires supporting ruby files with custom matchers and macros, etc,


### PR DESCRIPTION
RSpec produced the following deprecation warning, which is resolved by not
requiring `rspec/autorun` in spec/spec_helper.rb:

    Requiring `rspec/autorun` when running RSpec via the `rspec` command is deprecated. Called from /Users/caleb/.rvm/gems/ruby-2.3.0@ifme/gems/activesupport-4.2.5/lib/active_support/dependencies.rb:274:in `require'.