### PR TITLE
Remove protected_attributes gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,6 @@ gem 'spring',        group: :development
 
 gem "ruby-graphviz"
 
-gem 'protected_attributes'
-
 gem 'rails_12factor', group: :production
 
 gem 'ckeditor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,8 +207,6 @@ GEM
     orm_adapter (0.5.0)
     os (0.9.6)
     pg (0.18.4)
-    protected_attributes (1.1.3)
-      activemodel (>= 4.0.1, < 5.0)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -389,7 +387,6 @@ DEPENDENCIES
   omniauth
   omniauth-google-oauth2
   pg
-  protected_attributes
   pry-rails
   pusher
   railroady
@@ -414,4 +411,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.12.2
+   1.12.4

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,249 +1,247 @@
 module UserRelation
-	mattr_accessor :myself, :ally, :incoming_request, :outgoing_request, :other
-	MYSELF = 0
-	ALLY = 1
-	INCOMING_REQUEST = 2
-	OUTGOING_REQUEST = 3
-	OTHER = 4
+  mattr_accessor :myself, :ally, :incoming_request, :outgoing_request, :other
+  MYSELF = 0
+  ALLY = 1
+  INCOMING_REQUEST = 2
+  OUTGOING_REQUEST = 3
+  OTHER = 4
 end
 
 class ApplicationController < ActionController::Base
-	include ActionView::Helpers::UrlHelper
-  	# Prevent CSRF attacks by raising an exception.
-  	# For APIs, you may want to use :null_session instead.
-  	protect_from_forgery with: :null_session, if: Proc.new { |c| c.request.format == 'application/json' }
-  	before_filter :configure_permitted_parameters, if: :devise_controller?
+  include ActionView::Helpers::UrlHelper
+    # Prevent CSRF attacks by raising an exception.
+    # For APIs, you may want to use :null_session instead.
+    protect_from_forgery with: :null_session, if: Proc.new { |c| c.request.format == 'application/json' }
+    before_filter :configure_permitted_parameters, if: :devise_controller?
 
-  	protected
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.for(:account_update) { |u| u.permit(:location, :name, :email, :password, :password_confirmation, :current_password, :timezone, :about, :avatar, :comment_notify, :ally_notify, :group_notify, :meeting_notify) }
 
-  	def configure_permitted_parameters
-  		devise_parameter_sanitizer.for(:account_update) { |u| u.permit(:location, :name, :email, :password, :password_confirmation, :current_password, :timezone, :about, :avatar, :comment_notify, :ally_notify, :group_notify, :meeting_notify) }
+      devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:location, :name, :email, :password, :password_confirmation, :current_password, :timezone) }
+  end
 
-  		devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:location, :name, :email, :password, :password_confirmation, :current_password, :timezone) }
-	end
+  helper_method :fetch_taxonomies, :fetch_supporters, :avatar_url, :fetch_profile_picture, :no_taxonomies_error, :is_viewer, :are_allies, :print_list_links, :get_uid, :most_focus, :tag_usage, :can_notify
 
-	helper_method :fetch_taxonomies, :fetch_supporters, :avatar_url, :fetch_profile_picture, :no_taxonomies_error, :is_viewer, :are_allies, :print_list_links, :get_uid, :most_focus, :tag_usage, :can_notify
+  def are_allies(userid1, userid2)
+    userid1_allies = User.find(userid1).allies_by_status(:accepted)
+    return userid1_allies.include? User.find(userid2)
+  end
 
-	def are_allies(userid1, userid2)
-		userid1_allies = User.find(userid1).allies_by_status(:accepted)
-		return userid1_allies.include? User.find(userid2)
-	end
+  def is_viewer(viewers)
+    if (viewers.include? current_user.id)
+      return true
+    end
 
-	def is_viewer(viewers)
-		if (viewers.include? current_user.id)
-			return true
-		end
+    return false
+  end
 
-		return false
-	end
-
-	def get_uid(userid)
-		uid = User.where(id: userid).first.uid
-		return uid
-	end
+  def get_uid(userid)
+    uid = User.where(id: userid).first.uid
+    return uid
+  end
 
 ## Taxonomies are used for pluralization?
 ## unless the pluralization is non-standard, Rails can do this with .pluralize.
 
-	def no_taxonomies_error(taxonomy)
-		return "<span id='#{taxonomy}_quick_button' class='link_style small_margin_top'>Add #{taxonomy}</span>".html_safe
-	end
+  def no_taxonomies_error(taxonomy)
+    return "<span id='#{taxonomy}_quick_button' class='link_style small_margin_top'>Add #{taxonomy}</span>".html_safe
+  end
 
-	def fetch_taxonomies(data, data_type, item, taxonomy, show, list)
-		if taxonomy == "category" && Category.where(:id => item.to_i).exists?
-			if !Category.where(:id => item.to_i).first.description.blank?
-				link_name = Category.where(:id => item.to_i).first.name
-				link_url = '/categories/' + item.to_s
-				if show
-					link_url += '?' + data_type.to_s + '=' + data.id.to_s
-				end
-				return_this = link_to link_name, link_url
-			else
-				return_this = Category.where(:id => item.to_i).first.name
-			end
-			if item != data.category.last and list
-				return_this += ', '
-			end
-		elsif taxonomy == "mood" && Mood.where(:id => item.to_i).exists?
-			if !Mood.where(:id => item.to_i).first.description.blank?
-				link_name = Mood.where(:id => item.to_i).first.name
-				link_url = '/moods/' + item.to_s
-				if show
-					link_url += '?' + data_type.to_s + '=' + data.id.to_s
-				end
-				return_this = link_to link_name, link_url
-			else
-				return_this = Mood.where(:id => item.to_i).first.name
-			end
-			if item != data.mood.last and list
-				return_this += ', '
-			end
-		elsif taxonomy == "strategy" && Strategy.where(:id => item.to_i).exists?
-			if !Strategy.where(:id => item.to_i).first.description.blank?
-				link_name = Strategy.where(:id => item.to_i).first.name
-				link_url = '/strategies/' + item.to_s
-				if show
-					link_url += '?' + data_type.to_s + '=' + data.id.to_s
-				end
-				return_this = link_to link_name, link_url
-			else
-				return_this = Strategy.where(:id => item.to_i).first.name
-			end
-			if item != data.strategies.last and list
-				return_this += ', '
-			end
-		end
+  def fetch_taxonomies(data, data_type, item, taxonomy, show, list)
+    if taxonomy == "category" && Category.where(:id => item.to_i).exists?
+      if !Category.where(:id => item.to_i).first.description.blank?
+        link_name = Category.where(:id => item.to_i).first.name
+        link_url = '/categories/' + item.to_s
+        if show
+          link_url += '?' + data_type.to_s + '=' + data.id.to_s
+        end
+        return_this = link_to link_name, link_url
+      else
+        return_this = Category.where(:id => item.to_i).first.name
+      end
+      if item != data.category.last and list
+        return_this += ', '
+      end
+    elsif taxonomy == "mood" && Mood.where(:id => item.to_i).exists?
+      if !Mood.where(:id => item.to_i).first.description.blank?
+        link_name = Mood.where(:id => item.to_i).first.name
+        link_url = '/moods/' + item.to_s
+        if show
+          link_url += '?' + data_type.to_s + '=' + data.id.to_s
+        end
+        return_this = link_to link_name, link_url
+      else
+        return_this = Mood.where(:id => item.to_i).first.name
+      end
+      if item != data.mood.last and list
+        return_this += ', '
+      end
+    elsif taxonomy == "strategy" && Strategy.where(:id => item.to_i).exists?
+      if !Strategy.where(:id => item.to_i).first.description.blank?
+        link_name = Strategy.where(:id => item.to_i).first.name
+        link_url = '/strategies/' + item.to_s
+        if show
+          link_url += '?' + data_type.to_s + '=' + data.id.to_s
+        end
+        return_this = link_to link_name, link_url
+      else
+        return_this = Strategy.where(:id => item.to_i).first.name
+      end
+      if item != data.strategies.last and list
+        return_this += ', '
+      end
+    end
 
-		return return_this
-	end
+    return return_this
+  end
 
-	def fetch_supporters(support, type)
-		supporters = false
-		first_element = 0
-		return_this = ''
-		support.each do |s|
-			if s.support_ids.include?(type.id)
-				supporters = true
-				first_element = first_element + 1
-				link_url = '/profile?userid=' + s.userid.to_s
-				if first_element == 1
-					if s.userid == current_user.id
-         				return_this = link_to "You", link_url
-         			else
-         				return_this = link_to User.where(:id => s.userid).first.name, link_url
-         			end
-         		else
-         			return_this += ", "
-         			if s.userid == current_user.id
-         				return_this += link_to "You", link_url
-         			else
-         				return_this += link_to User.where(:id => s.userid).first.name, link_url
-         			end
-         		end
-      		end
-      	end
+  def fetch_supporters(support, type)
+    supporters = false
+    first_element = 0
+    return_this = ''
+    support.each do |s|
+      if s.support_ids.include?(type.id)
+        supporters = true
+        first_element = first_element + 1
+        link_url = '/profile?userid=' + s.userid.to_s
+        if first_element == 1
+          if s.userid == current_user.id
+                return_this = link_to "You", link_url
+              else
+                return_this = link_to User.where(:id => s.userid).first.name, link_url
+              end
+            else
+              return_this += ", "
+              if s.userid == current_user.id
+                return_this += link_to "You", link_url
+              else
+                return_this += link_to User.where(:id => s.userid).first.name, link_url
+              end
+            end
+          end
+        end
 
-      	if supporters
-      		return_this = "<br><strong>Supporters:</strong> " + return_this
-      	else
-      		return_this = ""
-      	end
+        if supporters
+          return_this = "<br><strong>Supporters:</strong> " + return_this
+        else
+          return_this = ""
+        end
 
-      	return return_this.html_safe
-	end
+        return return_this.html_safe
+  end
 
-	def fetch_profile_picture(avatar, class_name)
-		if avatar
-			profile = avatar
-		else 
-			profile = "/assets/default_ifme_avatar.png"
-		end
+  def fetch_profile_picture(avatar, class_name)
+    if avatar
+      profile = avatar
+    else
+      profile = "/assets/default_ifme_avatar.png"
+    end
 
-		result = "<div class='" + class_name.to_s + "' style='background: url(" + profile + ")'></div>"
+    result = "<div class='" + class_name.to_s + "' style='background: url(" + profile + ")'></div>"
 
-		return result.html_safe
-	end
+    return result.html_safe
+  end
 
-	def print_list_links(data)
-		first_element = 0
-		return_this = ''
-		data.each do |d|
-			first_element = first_element + 1
-			if first_element == 1
-     			return_this = link_to d[0], d[1]
-     		else
-     			return_this += ", "
-     			return_this += link_to d[0], d[1]
-     		end
-      	end
+  def print_list_links(data)
+    first_element = 0
+    return_this = ''
+    data.each do |d|
+      first_element = first_element + 1
+      if first_element == 1
+          return_this = link_to d[0], d[1]
+        else
+          return_this += ", "
+          return_this += link_to d[0], d[1]
+        end
+        end
 
-      	return return_this.html_safe
-	end
+        return return_this.html_safe
+  end
 
-	def most_focus(data_type)
-		data = Array.new
-		if data_type == 'category'
-			Moment.where(userid: current_user.id).all.each do |moment|
-				if !moment.category.blank? && moment.category.length > 0
-					data += moment.category
-				end
-			end
-			Strategy.where(userid: current_user.id).all.each do |strategy|
-				if !strategy.category.blank? && strategy.category.length > 0
-					data += strategy.category
-				end
-			end
-		elsif data_type == 'mood'
-			Moment.where(userid: current_user.id).all.each do |moment|
-				if !moment.mood.blank? && moment.mood.length > 0
-					data += moment.mood
-				end
-			end
-		elsif data_type == 'strategy'
-			Moment.where(userid: current_user.id).all.each do |moment|
-				if !moment.strategies.blank? && moment.strategies.length > 0
-					data += moment.strategies
-				end
-			end
-		end
+  def most_focus(data_type)
+    data = Array.new
+    if data_type == 'category'
+      Moment.where(userid: current_user.id).all.each do |moment|
+        if !moment.category.blank? && moment.category.length > 0
+          data += moment.category
+        end
+      end
+      Strategy.where(userid: current_user.id).all.each do |strategy|
+        if !strategy.category.blank? && strategy.category.length > 0
+          data += strategy.category
+        end
+      end
+    elsif data_type == 'mood'
+      Moment.where(userid: current_user.id).all.each do |moment|
+        if !moment.mood.blank? && moment.mood.length > 0
+          data += moment.mood
+        end
+      end
+    elsif data_type == 'strategy'
+      Moment.where(userid: current_user.id).all.each do |moment|
+        if !moment.strategies.blank? && moment.strategies.length > 0
+          data += moment.strategies
+        end
+      end
+    end
 
-		# Determine top three occurrences
-		result = Hash.new
+    # Determine top three occurrences
+    result = Hash.new
 
-		if data.length > 0
-			freq = Hash.new
-			for i in 0..2
-				freq = data.inject(Hash.new(0)) { |h,v| h[v] += 1; h }
-	   			if freq.length == 0
-	   				break
-	   			end
+    if data.length > 0
+      freq = Hash.new
+      for i in 0..2
+        freq = data.inject(Hash.new(0)) { |h,v| h[v] += 1; h }
+          if freq.length == 0
+            break
+          end
 
-	   			max = data.max_by { |v| freq[v] }
-	   			if freq[max] == 0
-	   				break
-	   			end
+          max = data.max_by { |v| freq[v] }
+          if freq[max] == 0
+            break
+          end
 
-	   			result[max] = freq[max]
-				freq.delete(max)
-				data.delete(max)
-			end
-		end
-		
-		return result
-	end
+          result[max] = freq[max]
+        freq.delete(max)
+        data.delete(max)
+      end
+    end
 
-	def tag_usage(data, data_type, userid)
-		result = Array.new
-		if (data_type == 'category')
-			moments = Array.new
-			Moment.where(userid: userid).order("created_at DESC").all.each do |moment|		
-				if !moment.category.blank? && moment.category.length > 0 && moment.category.include?(data.to_i)
-					moments.push(moment.id)
-				end
-			end
-			result.push(moments)
+    return result
+  end
 
-			strategies = Array.new
-			Strategy.where(userid: userid).order("created_at DESC").all.each do |strategy|		
-				if !strategy.category.blank? && strategy.category.length > 0 && strategy.category.include?(data.to_i)
-					strategies.push(strategy.id)
-				end
-			end
-			result.push(strategies)
-		elsif (data_type == 'mood')
-			Moment.where(userid: userid).order("created_at DESC").all.each do |moment|		
-				if !moment.mood.blank? && moment.mood.length > 0 && moment.mood.include?(data.to_i)
-					result.push(moment.id)
-				end
-			end
-		elsif (data_type == 'strategy')
-			Moment.where(userid: userid).order("created_at DESC").all.each do |moment|		
-				if !moment.strategies.blank? && moment.strategies.length > 0 && moment.strategies.include?(data.to_i)
-					result.push(moment.id)
-				end
-			end
-		end
+  def tag_usage(data, data_type, userid)
+    result = Array.new
+    if (data_type == 'category')
+      moments = Array.new
+      Moment.where(userid: userid).order("created_at DESC").all.each do |moment|
+        if !moment.category.blank? && moment.category.length > 0 && moment.category.include?(data.to_i)
+          moments.push(moment.id)
+        end
+      end
+      result.push(moments)
 
-		return result
-	end
+      strategies = Array.new
+      Strategy.where(userid: userid).order("created_at DESC").all.each do |strategy|
+        if !strategy.category.blank? && strategy.category.length > 0 && strategy.category.include?(data.to_i)
+          strategies.push(strategy.id)
+        end
+      end
+      result.push(strategies)
+    elsif (data_type == 'mood')
+      Moment.where(userid: userid).order("created_at DESC").all.each do |moment|
+        if !moment.mood.blank? && moment.mood.length > 0 && moment.mood.include?(data.to_i)
+          result.push(moment.id)
+        end
+      end
+    elsif (data_type == 'strategy')
+      Moment.where(userid: userid).order("created_at DESC").all.each do |moment|
+        if !moment.strategies.blank? && moment.strategies.length > 0 && moment.strategies.include?(data.to_i)
+          result.push(moment.id)
+        end
+      end
+    end
+
+    return result
+  end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,15 +1,14 @@
 class RegistrationsController < Devise::RegistrationsController
-  protected
-    def after_update_path_for(resource)
-    	edit_user_registration_path
-    end
+  def after_update_path_for(resource)
+    edit_user_registration_path
+  end
 
-  	def update_resource(resource, params)
-	    if current_user.provider == "google_oauth2"
-	      params.delete("current_password")
-	      resource.update_without_password(params)
-	    else
-	      resource.update_with_password(params)
-	    end
-  	end
+  def update_resource(resource, params)
+    if current_user.provider == "google_oauth2"
+      params.delete("current_password")
+      resource.update_without_password(params)
+    else
+      resource.update_with_password(params)
+    end
+  end
 end

--- a/app/models/allyship.rb
+++ b/app/models/allyship.rb
@@ -11,25 +11,24 @@
 #
 
 class Allyship < ActiveRecord::Base
-	attr_accessible :status, :user_id, :ally_id
-	enum status: [:accepted, :pending_from_user, :pending_from_ally]
+  enum status: [:accepted, :pending_from_user, :pending_from_ally]
 
-	validate :different_users
+  validate :different_users
 
-	belongs_to :user
-	belongs_to :ally, class_name: "User"
+  belongs_to :user
+  belongs_to :ally, class_name: "User"
 
-	after_create :create_inverse, unless: :has_inverse?
-	after_update :approve_inverse, if: :inverse_unapproved?
-	after_destroy :destroy_inverses, if: :has_inverse?
+  after_create :create_inverse, unless: :has_inverse?
+  after_update :approve_inverse, if: :inverse_unapproved?
+  after_destroy :destroy_inverses, if: :has_inverse?
 
-	def create_inverse
+  def create_inverse
     self.class.create(inverse_allyship_options.merge({ status: User::ALLY_STATUS[:pending_from_user] }))
   end
 
-	def approve_inverse
-		inverses.update_all(status: User::ALLY_STATUS[:accepted])
-	end
+  def approve_inverse
+    inverses.update_all(status: User::ALLY_STATUS[:accepted])
+  end
 
   def destroy_inverses
     inverses.destroy_all
@@ -39,9 +38,9 @@ class Allyship < ActiveRecord::Base
     self.class.exists?(inverse_allyship_options)
   end
 
-	def inverse_unapproved?
-		!inverses.where.not(status: User::ALLY_STATUS[:accepted]).empty?
-	end
+  def inverse_unapproved?
+    !inverses.where.not(status: User::ALLY_STATUS[:accepted]).empty?
+  end
 
   def inverses
     self.class.where(inverse_allyship_options)
@@ -51,9 +50,9 @@ class Allyship < ActiveRecord::Base
     { ally_id: user_id, user_id: ally_id }
   end
 
-	def different_users
-		self.errors.add(:user_id, "identical users") if self.user_id == self.ally_id
-		self.errors.add(:user_id, "user_id is nil") if self.user_id.nil?
-		self.errors.add(:ally_id, "ally_id is nil") if self.ally_id.nil?
-	end
+  def different_users
+    self.errors.add(:user_id, "identical users") if self.user_id == self.ally_id
+    self.errors.add(:user_id, "user_id is nil") if self.user_id.nil?
+    self.errors.add(:ally_id, "ally_id is nil") if self.ally_id.nil?
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -11,7 +11,6 @@
 #
 
 class Category < ActiveRecord::Base
-	attr_accessible :name, :description, :userid
-	validates_length_of :description, :maximum => 2000
-	validates_presence_of :userid, :name
+  validates_length_of :description, :maximum => 2000
+  validates_presence_of :userid, :name
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,18 +13,17 @@
 #
 
 class Comment < ActiveRecord::Base
-	attr_accessible :comment_type, :commented_on, :comment_by, :comment, :visibility, :viewers
-	serialize :viewers, Array
-	validates_length_of :comment, :minimum => 0, :maximum => 1000
-	validates_presence_of :comment_type, :commented_on, :comment_by, :comment
-	validates :comment_type, inclusion: %w(moment strategy meeting)
-	validates :visibility, inclusion: %w(all private)
-	before_save :array_data
+  serialize :viewers, Array
+  validates_length_of :comment, :minimum => 0, :maximum => 1000
+  validates_presence_of :comment_type, :commented_on, :comment_by, :comment
+  validates :comment_type, inclusion: %w(moment strategy meeting)
+  validates :visibility, inclusion: %w(all private)
+  before_save :array_data
 
-	def array_data
-		if !self.viewers.nil? && self.viewers.is_a?(Array)
-			self.viewers = self.viewers.collect{|i| i.to_i}
-		end
-	end
+  def array_data
+    if !self.viewers.nil? && self.viewers.is_a?(Array)
+      self.viewers = self.viewers.collect{|i| i.to_i}
+    end
+  end
 
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,7 +10,5 @@
 #
 
 class Group < ActiveRecord::Base
-	attr_accessible :name, :description
-
-	validates_presence_of :name, :description
+  validates_presence_of :name, :description
 end

--- a/app/models/group_member.rb
+++ b/app/models/group_member.rb
@@ -11,8 +11,6 @@
 #
 
 class GroupMember < ActiveRecord::Base
-	attr_accessible :groupid, :userid, :leader
-
-	validates_presence_of :groupid, :userid
-	validates :leader, inclusion: [true, false]
+  validates_presence_of :groupid, :userid
+  validates :leader, inclusion: [true, false]
 end

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -18,15 +18,13 @@
 #
 
 class Medication < ActiveRecord::Base
-	attr_accessible :name, :dosage, :refill, :userid, :total, :strength, :dosage_unit, :total_unit, :strength_unit, :comments
+  # dosage: amount of medication taken at one time
+  # total: total quantity of medication
+  # strength: strength of medication
 
-	# dosage: amount of medication taken at one time
-	# total: total quantity of medication
-	# strength: strength of medication
+  validates_presence_of :name, :dosage, :refill, :userid, :total, :strength, :dosage_unit, :total_unit, :strength_unit
 
-	validates_presence_of :name, :dosage, :refill, :userid, :total, :strength, :dosage_unit, :total_unit, :strength_unit
-
-	validates :dosage, :numericality => { :greater_than_or_equal_to => 0 }
-	validates :total, :numericality => { :greater_than_or_equal_to => 0 }
-	validates :strength, :numericality => { :greater_than_or_equal_to => 0 }
+  validates :dosage, :numericality => { :greater_than_or_equal_to => 0 }
+  validates :total, :numericality => { :greater_than_or_equal_to => 0 }
+  validates :strength, :numericality => { :greater_than_or_equal_to => 0 }
 end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -15,7 +15,5 @@
 #
 
 class Meeting < ActiveRecord::Base
-	attr_accessible :name, :description, :location, :time, :maxmembers, :groupid, :date
-
-	validates_presence_of :name, :description, :location, :time, :groupid, :date
+  validates_presence_of :name, :description, :location, :time, :groupid, :date
 end

--- a/app/models/meeting_member.rb
+++ b/app/models/meeting_member.rb
@@ -11,8 +11,6 @@
 #
 
 class MeetingMember < ActiveRecord::Base
-	attr_accessible :meetingid, :userid, :leader
-
-	validates_presence_of :meetingid, :userid
-	validates :leader, inclusion: [true, false]
+  validates_presence_of :meetingid, :userid
+  validates :leader, inclusion: [true, false]
 end

--- a/app/models/moment.rb
+++ b/app/models/moment.rb
@@ -17,30 +17,29 @@
 #
 
 class Moment < ActiveRecord::Base
-	attr_accessible :category, :name, :mood, :why, :fix, :userid, :viewers, :comment, :strategies
-	serialize :category, Array
-	serialize :viewers, Array
-	serialize :mood, Array
-	serialize :strategies, Array
-	validates :comment, inclusion: [true, false]
-	validates_presence_of :userid, :name, :why
-	validates_length_of :why, :minimum => 1, :maximum => 2000
-	validates_length_of :fix, :maximum => 2000
-	before_save :array_data
+  serialize :category, Array
+  serialize :viewers, Array
+  serialize :mood, Array
+  serialize :strategies, Array
+  validates :comment, inclusion: [true, false]
+  validates_presence_of :userid, :name, :why
+  validates_length_of :why, :minimum => 1, :maximum => 2000
+  validates_length_of :fix, :maximum => 2000
+  before_save :array_data
 
-	def array_data
-		if !self.category.nil? && self.category.is_a?(Array)
-			self.category = self.category.collect{|i| i.to_i}
-		end
-		if !self.viewers.nil? && self.viewers.is_a?(Array)
-			self.viewers = self.viewers.collect{|i| i.to_i}
-		end
-		if !self.mood.nil? && self.mood.is_a?(Array)
-			self.mood = self.mood.collect{|i| i.to_i}
-		end
-		if !self.strategies.nil? && self.strategies.is_a?(Array)
-			self.strategies = self.strategies.collect{|i| i.to_i}
-		end
-	end
+  def array_data
+    if !self.category.nil? && self.category.is_a?(Array)
+      self.category = self.category.collect{|i| i.to_i}
+    end
+    if !self.viewers.nil? && self.viewers.is_a?(Array)
+      self.viewers = self.viewers.collect{|i| i.to_i}
+    end
+    if !self.mood.nil? && self.mood.is_a?(Array)
+      self.mood = self.mood.collect{|i| i.to_i}
+    end
+    if !self.strategies.nil? && self.strategies.is_a?(Array)
+      self.strategies = self.strategies.collect{|i| i.to_i}
+    end
+  end
 
 end

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -11,7 +11,6 @@
 #
 
 class Mood < ActiveRecord::Base
-	attr_accessible :name, :description, :userid
-	validates_length_of :description, :maximum => 2000
-	validates_presence_of :userid, :name
+  validates_length_of :description, :maximum => 2000
+  validates_presence_of :userid, :name
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -9,6 +9,5 @@
 #
 
 class Notification < ActiveRecord::Base
-	attr_accessible :userid, :uniqueid, :data
-	validates_presence_of :userid, :uniqueid, :data
+  validates_presence_of :userid, :uniqueid, :data
 end

--- a/app/models/strategy.rb
+++ b/app/models/strategy.rb
@@ -14,20 +14,19 @@
 #
 
 class Strategy < ActiveRecord::Base
-	attr_accessible :userid, :category, :description, :viewers, :comment, :name
-	serialize :category, Array
-	serialize :viewers, Array
-	validates :comment, inclusion: [true, false]
-	validates_presence_of :userid, :name, :description
-	validates_length_of :description, :minimum => 1, :maximum => 2000
-	before_save :array_data
+  serialize :category, Array
+  serialize :viewers, Array
+  validates :comment, inclusion: [true, false]
+  validates_presence_of :userid, :name, :description
+  validates_length_of :description, :minimum => 1, :maximum => 2000
+  before_save :array_data
 
-	def array_data
-		if !self.category.nil? && self.category.is_a?(Array)
-			self.category = self.category.collect{|i| i.to_i}
-		end
-		if !self.viewers.nil? && self.viewers.is_a?(Array)
-			self.viewers = self.viewers.collect{|i| i.to_i}
-		end
-	end
+  def array_data
+    if !self.category.nil? && self.category.is_a?(Array)
+      self.category = self.category.collect{|i| i.to_i}
+    end
+    if !self.viewers.nil? && self.viewers.is_a?(Array)
+      self.viewers = self.viewers.collect{|i| i.to_i}
+    end
+  end
 end

--- a/app/models/support.rb
+++ b/app/models/support.rb
@@ -11,15 +11,14 @@
 #
 
 class Support < ActiveRecord::Base
-	attr_accessible :userid, :support_type, :support_ids
-	validates_presence_of :userid, :support_type, :support_ids
-	serialize :support_ids, Array
-	validates :support_type, inclusion: %w(category mood moment strategy)
-	before_save :array_data
+  validates_presence_of :userid, :support_type, :support_ids
+  serialize :support_ids, Array
+  validates :support_type, inclusion: %w(category mood moment strategy)
+  before_save :array_data
 
-	def array_data
-		if !self.support_ids.nil? && self.support_ids.is_a?(Array)
-			self.support_ids = self.support_ids.collect{|i| i.to_i}
-		end
-	end
+  def array_data
+    if !self.support_ids.nil? && self.support_ids.is_a?(Array)
+      self.support_ids = self.support_ids.collect{|i| i.to_i}
+    end
+  end
 end

--- a/spec/models/moment_spec.rb
+++ b/spec/models/moment_spec.rb
@@ -22,18 +22,18 @@ describe Moment do
 	describe "POST create" do
 		it "create private moment" do
 			new_user = create(:user1)
-		 	new_category = create(:category, userid: new_user.id)
-		  	new_mood = create(:mood, userid: new_user.id)
-		  	new_moment = create(:moment, userid: new_user.id, category: Array.new(1, new_category.id), mood: Array.new(1, new_mood.id))
-		  	expect(new_moment.viewers).to be_empty
+			new_category = create(:category, userid: new_user.id)
+				new_mood = create(:mood, userid: new_user.id)
+				new_moment = create(:moment, userid: new_user.id, category: Array.new(1, new_category.id), mood: Array.new(1, new_mood.id))
+				expect(new_moment.viewers).to be_empty
 		  end
 	end
 	describe "POST create" do
 		it "create public moment" do
-		 	new_user = create(:user1)
-		 	new_user2 = create(:user2)
-		 	new_allies = create(:allyships_accepted, user_id: new_user.id, ally_id: new_user2.id)
-		  	new_category = create(:category, userid: new_user.id)
+			new_user = create(:user1)
+			new_user2 = create(:user2)
+			new_allies = create(:allyships_accepted, user_id: new_user.id, ally_id: new_user2.id)
+				new_category = create(:category, userid: new_user.id)
 			new_mood = create(:mood, userid: new_user.id)
 			new_moment = create(:moment, userid: new_user.id, category: Array.new(1, new_category.id), mood: Array.new(1, new_mood.id), viewers: [new_user2.id])
 			expect(new_moment.viewers.count).to eq(1)


### PR DESCRIPTION
[Protected attributes] were an extraction from rails 3.2 to allow continued
use of an old style of mass assignment protection. They were replaced by the
strong_parameters gem which is a part of Rails 4+. The protected_attributes
gem won't be supported past the forthcoming rails 5.0 release, and it's not
doing much for us so let's drop it.

[Protected attributes]: https://github.com/rails/protected_attributes

I also included some opportunistic refactorings as I came along them.

This PR is best reviewed with ?w=1 as there are many, many tabs being removed.