### PR TITLE
Fix bug where a user couldn't log in with oauth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,14 +56,17 @@ class User < ActiveRecord::Base
 
   def self.find_for_google_oauth2(access_token, signed_in_resource=nil)
     data = access_token.info
-    find_or_initialize_by(email: data.email) do |user|
+    user = find_or_initialize_by(email: data.email) do |user|
       user.name = data.name
       user.password = Devise.friendly_token[0,20]
-    end.update!(
+    end
+
+    user.update!(
         provider: access_token.provider,
         token: access_token.credentials.token,
         uid: access_token.uid,
       )
+    user
   end
 
    def allies_by_status(status)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe User do
+  describe ".find_for_google_oauth2" do
+    let(:access_token) { 
+      double({ 
+                info: double({ email: "some@user.com", name: "some name" }),
+                provider: "asdf",
+                credentials: double({ token: "some token" }),
+                uid: "some uid"
+      })
+    }
+
+    context "an existing user" do
+      let!(:user) { User.create(email: "some@user.com", password: "asdfasdf") }
+
+      it "updates token information" do
+        User.find_for_google_oauth2(access_token)
+        user.reload
+        expect(user.provider).to eq("asdf")
+        expect(user.token).to eq("some token")
+        expect(user.uid).to eq("some uid")
+      end
+
+      it "returns a user" do
+        expect(User.find_for_google_oauth2(access_token)).to eq(user.reload)
+      end
+    end
+
+    context "a new user" do
+      it "creates a new user" do
+        expect(User.where(email: "some@user.com").first).to be_nil
+        User.find_for_google_oauth2(access_token)
+        expect(User.where(email: "some@user.com").first).to be_a_kind_of(User)
+      end
+
+      it "returns a user" do
+        expect(User.find_for_google_oauth2(access_token)).to be_a_kind_of(User)
+      end
+    end
+  end  
+end


### PR DESCRIPTION
I realized when I was trying to set up my local environment that there was a regression in the oauth login.

User.find_for_google_oauth2 originally returned a user object, which oauth used
to authenticate when redirecting the user to their homepage. In commit
e68e37a, it started returning a true/false value from update!. This
commit switches it back to returning a user and adds specs.