### PR TITLE
Cleaning up the set_group method

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -245,15 +245,11 @@ class GroupsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_group
-      begin
-        @group = Group.find(params[:id])
-      rescue
-        if @group.blank?
-          respond_to do |format|
-            format.html { redirect_to groups_path }
-            format.json { head :no_content }
-          end
-        end
+      @group = Group.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      respond_to do |format|
+        format.html { redirect_to groups_path }
+        format.json { head :no_content }
       end
     end
 


### PR DESCRIPTION
This is how I've seen the not found handled in other places. It cleans
things up a little bit