### PR TITLE
Adding leaders relation to meeting model

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -18,4 +18,8 @@ class Meeting < ActiveRecord::Base
   validates_presence_of :name, :description, :location, :time, :groupid, :date
 
   belongs_to :group, foreign_key: :groupid
+
+  has_many :meeting_members, foreign_key: :meetingid
+  has_many :leaders, -> { where(meeting_members: { leader: true }) },
+           through: :meeting_members, source: :user
 end

--- a/app/models/meeting_member.rb
+++ b/app/models/meeting_member.rb
@@ -13,4 +13,7 @@
 class MeetingMember < ActiveRecord::Base
   validates_presence_of :meetingid, :userid
   validates :leader, inclusion: [true, false]
+
+  belongs_to :meeting, foreign_key: :meetingid
+  belongs_to :user, foreign_key: :userid
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -24,6 +24,7 @@ FactoryGirl.define do
     time "Test Time"
     maxmembers 1
     date Date.tomorrow
+    sequence(:groupid)
   end
 
   factory :bad_group, class: Group do

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -17,13 +17,46 @@
 require 'spec_helper'
 
 describe Meeting do
- 	it "creates a meeting" do
- 		new_group = create(:group, description: 'Test Description')
- 		new_meeting = create(:meeting, groupid: new_group.id, date: 'May 1, 2015')
-	  	expect(Meeting.count).to eq(1)
- 	end
- 	it "does not create a meeting" do
- 		new_meeting = build(:meeting)
-	  	expect(new_meeting).to have(1).error_on(:groupid)
- 	end
+  it "has a valid factory" do
+    result = build :meeting
+
+    expect(result).to be_valid
+  end
+  context "when meeting does not have a group id" do
+    it "is not valid" do
+      new_meeting = build(:meeting, groupid: nil)
+      expect(new_meeting).to have(1).error_on(:groupid)
+    end
+  end
+
+  describe ".leaders" do
+    context "when group has leaders" do
+      it "returns the leaders" do
+        leader = create :user1
+        non_leader = create :user2
+        meeting = create :meeting
+        create :meeting_member, userid: leader.id, leader: true,
+                                meetingid: meeting.id
+        create :meeting_member, userid: non_leader.id, leader: false,
+                                meetingid: meeting.id
+
+        result = meeting.leaders
+
+        expect(result).to eq [leader]
+      end
+    end
+
+    context "when group has no leaders" do
+      it "returns an empty array" do
+        non_leader = create :user1
+        meeting = create :meeting
+        create :meeting_member, userid: non_leader.id, leader: false,
+                                meetingid: meeting.id
+
+        result = meeting.leaders
+
+        expect(result).to eq []
+      end
+    end
+  end
 end


### PR DESCRIPTION
This will allow us to easily call meeting.leaders or eager load
group.meetings.includes(:leaders)