### PR TITLE
Eager loading meeting leaders in controller

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -21,7 +21,7 @@ class GroupsController < ApplicationController
     @group_members = @group.group_members
     @is_group_member = @group.users.include? current_user
     if @is_group_member
-      @meetings = @group.meetings.order('created_at DESC')
+      @meetings = @group.meetings.includes(:leaders)
     end
     @group_leaders = @group.group_members.includes(:user).where(leader: true)
     @current_user_is_leader = @group.led_by?(current_user)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -14,7 +14,7 @@ class Group < ActiveRecord::Base
 
   has_many :group_members, foreign_key: :groupid
   has_many :users, through: :group_members
-  has_many :meetings, foreign_key: :groupid
+  has_many :meetings, -> { order 'created_at DESC' }, foreign_key: :groupid
 
   def led_by?(user)
     leaders.include?(user)

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -46,6 +46,8 @@
 <% if !@meetings.blank? && @meetings.length > 0 %>
   <div class="spacer"></div>
   <% @meetings.each do |meeting| %>
+    <% user_is_meeting_leader = meeting.leaders.include? current_user %>
+
     <% if @meetings.last == meeting %>
       <div class="meeting no_margin_bottom">
     <% else %>
@@ -55,8 +57,7 @@
       <% if @current_user_is_leader %>
         <h1 class="meeting_name">
           <%= link_to meeting.name, meeting_path(meeting) %>
-          <% if MeetingMember.where(meetingid: meeting.id,
-              userid: current_user.id, leader: true).exists? %>
+          <% if user_is_meeting_leader %>
             <%= link_to raw('<i class="fa fa-pencil"></i>'),
               edit_meeting_path(meeting),
               class: 'align_right display_inline_block' %>
@@ -69,9 +70,7 @@
       <% end %>
       <%= render partial: '/shared/meeting_info',
                  locals: { meeting: meeting,
-                           is_leader: MeetingMember.where(meetingid: meeting.id,
-                                                          userid: current_user.id,
-                                                          leader: true).exists? } %>
+                           is_leader: user_is_meeting_leader } %>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
* Updating view to use eager loaded leaders instead of querying
* Adding default order to group.meetings so that it doesn't have to be
 specified in the controller
* Setting user_is_meeting_leader as a variable at the top of the
meetings loop since it is needed more than once