### PR TITLE
Removing unnecessary instance variables

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -18,15 +18,12 @@ class GroupsController < ApplicationController
   # GET /groups/1.json
   def show
     @page_title = @group.name
-    @group_members = @group.group_members
-    @is_group_member = @group.users.include? current_user
-    if @is_group_member
+
+    if @group.users.include? current_user
       @meetings = @group.meetings.includes(:leaders)
     end
-    @group_leaders = @group.leaders
-    @current_user_is_leader = @group.led_by?(current_user)
 
-    if @current_user_is_leader
+    if @group.led_by?(current_user)
       @page_new = new_meeting_path(groupid: @group.id)
       @page_tooltip = "New meeting"
     end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -3,15 +3,15 @@
 <div class="notification_wrapper">
   <strong class="tip_notifications_button">
     <i class="fa fa-list small_margin_right"></i>
-    <%= @group_members.count %>
-    <% if @group_members.count == 1 %>
+    <%= @group.group_members.count %>
+    <% if @group.group_members.count == 1 %>
       <%= t('.member') %>
     <% else %>
       <%= t('.members') %>
     <% end %>
   </strong>
 
-  <%= render_group_member_partial(@group_members) %>
+  <%= render_group_member_partial(@group.group_members) %>
 </div>
 
 <strong>
@@ -19,19 +19,19 @@
   <%= t('.led_by') %>
 </strong>
 
-<% @group_leaders.each do |leader| %>
+<% @group.leaders.each do |leader| %>
   <% if leader == current_user %>
     <%= link_to t('.self'), profile_index_path(uid: leader.uid) %>
   <% else %>
     <%= link_to leader.name, profile_index_path(uid: leader.uid) %>
   <% end %>
 
-  <%= ',' unless leader == @group_leaders.last %>
+  <%= ',' unless leader == @group.leaders.last %>
 <% end %>
 
-<% if @current_user_is_leader && @group_members.count == 1 %>
+<% if @group.led_by?(current_user) && @group.group_members.count == 1 %>
   <%= delete_group_link(@group, class: 'align_right') %>
-<% elsif @is_group_member %>
+<% elsif @group.users.include? current_user %>
   <%= leave_group_link(@group, class: 'align_right') %>
 <% else %>
   <%= join_group_link(@group, class: 'align_right') %>


### PR DESCRIPTION
After some experimenting with rendering the page and watching the
console, I figured out (I think) that Rails doesn't evaluate instance
variables in the controller if it doesn't have to. This means that
when you set @group_members = @group.members, the query for group
members isn't made until @group_members is used in the view.
Furthermore, it looks like if @group.members is used more than once in
the view, the query to get the members is only made once. Therefore,
setting the @group_members variable doesn't have any advantage over
simply using @group.members in the view.