### PR TITLE
Alphabetize members in member partial

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -19,7 +19,7 @@ class GroupsController < ApplicationController
   def show
     @page_title = @group.name
 
-    if @group.users.include? current_user
+    if @group.members.include? current_user
       @meetings = @group.meetings.includes(:leaders)
     end
 

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -54,9 +54,8 @@ module GroupsHelper
     end
   end
 
-  def render_group_member_partial(members)
-    render partial: '/notifications/members',
-           locals: { data: members }
+  def render_group_member_partial(group)
+    render partial: '/notifications/members', locals: { group: group }
   end
 
   def render_meeting_partial(meeting)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -13,7 +13,7 @@ class Group < ActiveRecord::Base
   validates_presence_of :name, :description
 
   has_many :group_members, foreign_key: :groupid
-  has_many :users, through: :group_members
+  has_many :members, -> { order 'name' }, through: :group_members, source: :user
   has_many :meetings, -> { order 'created_at DESC' }, foreign_key: :groupid
   has_many :meetings, foreign_key: :groupid
   has_many :leaders, -> { where(group_members: { leader: true }) },

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -19,6 +19,8 @@ class Meeting < ActiveRecord::Base
 
   belongs_to :group, foreign_key: :groupid
 
+  has_many :members, -> { order 'name' }, through: :meeting_members,
+                                          source: :user
   has_many :meeting_members, foreign_key: :meetingid
   has_many :leaders, -> { where(meeting_members: { leader: true }) },
            through: :meeting_members, source: :user

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -19,7 +19,7 @@
           <%= group.group_members.count %>
           <%= member_pluralized_for(group) %>
         </strong>
-        <%= render_group_member_partial(group.group_members) %>
+        <%= render_group_member_partial(group) %>
       </div>
 
       <%= strip_tags(group.description[0..80]) %>
@@ -64,7 +64,7 @@
           <%= group.group_members.count %>
           <%= member_pluralized_for(group) %>
         </strong>
-        <%= render_group_member_partial(group.group_members) %>
+        <%= render_group_member_partial(group) %>
       </div>
 
       <%= strip_tags(group.description[0..80]) %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -9,7 +9,7 @@
       <%= @group.group_members.count %>
       <%= member_pluralized_for(@group) %>
     </strong>
-    <%= render_group_member_partial(@group.group_members) %>
+    <%= render_group_member_partial(@group) %>
   </div>
 
   <strong>
@@ -24,7 +24,7 @@
 
   <% if user_can_delete? @group %>
     <%= delete_group_link(@group, class: 'align_right') %>
-  <% elsif @group.users.include? current_user %>
+  <% elsif @group.members.include? current_user %>
     <%= leave_group_link(@group, class: 'align_right') %>
   <% else %>
     <%= join_group_link(@group, class: 'align_right') %>

--- a/app/views/notifications/_members.html.erb
+++ b/app/views/notifications/_members.html.erb
@@ -13,40 +13,35 @@
       </div>
     </div>
 
-    <% local_assigns[:data].each do |member| %>
+    <%# group can be an instance of either group or meeting %>
+    <% group.members.each do |member| %>
       <div class="table">
         <div class="table_row">
 
-          <% if local_assigns[:data].last == member %>
+          <% if group.members.last == member %>
             <div class="table_cell small_profile_picture_div padding_right">
           <% else %>
             <div class="table_cell small_profile_picture_div padding_right small_padding_bottom">
           <% end %>
 
-            <% profile = User.where(:id => member.userid).first %>
-            <%= fetch_profile_picture(profile.avatar.url, 'mini_profile_picture') %>
+            <%= fetch_profile_picture(member.avatar.url, 'mini_profile_picture') %>
             <br>
           </div>
 
-          <% if local_assigns[:data].last == member %>
+          <% if group.members.last == member %>
             <div class="table_cell vertical_align_middle">
           <% else %>
             <div class="table_cell small_padding_bottom vertical_align_middle">
           <% end %>
-          <%= link_to profile.name,
-                      profile_index_path(uid: get_uid(member.userid)) %>
+          <%= link_to member.name, profile_index_path(uid: member.uid) %>
 
-            <% if member.userid != current_user.id &&
-                local_assigns[:is_meeting_member].blank? &&
-                GroupMember.where(
-                  groupid: member.groupid,
-                  userid: current_user.id,
-                  leader: true
-                ).exists? %>
+          <% if member != current_user &&
+              group.instance_of?(Group) &&
+              group.leaders.include?(current_user) %>
               <i class="fa fa-times action small_margin_left"></i>
               <%= link_to t('notifications.members.remove'),
-                          leave_groups_path(groupid: member.groupid,
-                          memberid: member.userid), id: 'leave' %>
+                          leave_groups_path(groupid: group.id,
+                          memberid: member.id), id: 'leave' %>
             <% end %>
 
           </div>

--- a/app/views/shared/_meeting_info.html.erb
+++ b/app/views/shared/_meeting_info.html.erb
@@ -12,11 +12,24 @@
 <br><strong><%= t('groups.show.time') %></strong> <%= local_assigns[:meeting].time %>
 
 <div class="notification_wrapper">
-	<strong class="tip_notifications_button"><i class="fa fa-list small_margin_right"></i><%= MeetingMember.where(meetingid: local_assigns[:meeting].id).count %> <% if MeetingMember.where(meetingid: local_assigns[:meeting].id).count == 1 %><%= t('group.show.member') %><% else %><%= t('group.show.members') %><% end %></strong>
+  <strong class="tip_notifications_button">
+    <i class="fa fa-list small_margin_right"></i>
+    <%= MeetingMember.where(meetingid: local_assigns[:meeting].id).count %>
+    <% if MeetingMember.where(meetingid: local_assigns[:meeting].id).count == 1 %>
+      <%= t('groups.show.member') %>
+    <% else %>
+      <%= t('groups.show.members') %>
+    <% end %>
+  </strong>
 
-		<% if local_assigns[:show_group] %><strong><%= ' of ' %><%= link_to Group.where(id: local_assigns[:meeting].groupid).first.name, group_path(local_assigns[:meeting].groupid) %></strong><% end %>
+  <% if local_assigns[:show_group] %>
+    <strong><%= ' of ' %>
+    <%= link_to meeting.group.name, meeting.group %>
+    </strong>
+  <% end %>
 
-	<%= render :partial => '/notifications/members', locals: { data: MeetingMember.where(meetingid: local_assigns[:meeting].id).all, is_meeting_member: true } %>
+  <%= render :partial => '/notifications/members',
+    locals: { group: meeting } %>
 </div>
 
 <% if MeetingMember.where(meetingid: local_assigns[:meeting].id, userid: current_user.id).exists? %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -14,7 +14,8 @@ FactoryGirl.define do
   end
 
   factory :meeting_member do
-    userid 1
+    sequence(:userid)
+    leader false
   end
 
   factory :meeting do
@@ -51,7 +52,7 @@ FactoryGirl.define do
 
   factory :user1, class: User do
     name "Oprah Chang"
-    email "oprah.chang@example.com"
+    sequence(:email) { |n| "oprah.chang#{n}@example.com" }
     password "password"
     location "Toronto, ON, Canada"
     timezone "-05:00"

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -46,7 +46,7 @@ describe Group do
     end
   end
 
-  describe ".leaders" do
+  describe "#leaders" do
     context "when group has leaders" do
       it "returns the leaders" do
         leader = create :user1
@@ -70,6 +70,21 @@ describe Group do
 
         expect(result).to eq []
       end
+    end
+  end
+
+  describe "#members" do
+    it "returns group members in alphabetical order" do
+      group = create :group
+      names = ['bryan', 'charlie', 'alex']
+      names.each do |name|
+        user = create :user1, name: name
+        create :group_member, userid: user.id, groupid: group.id
+      end
+
+      result = group.members
+
+      expect(result.map(&:name)).to eq ['alex', 'bryan', 'charlie']
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,7 +38,7 @@ describe User do
         expect(User.find_for_google_oauth2(access_token)).to be_a_kind_of(User)
       end
     end
-  end  
+  end
 
   describe "#available_groups" do
     it "returns the groups that allys belong to and the user doesn't" do


### PR DESCRIPTION
Resolves #186

To do this, I added the has_many :members association to both Group and
Meeting and changed the notifications/_members partial so that it
can receive an instance of either group or meeting as the local variable
called group. Using this instance, the partial can get anything it needs
since both group and meeting respond to #leaders and #members. Instead
of passing a second :is_meeting_member local, we can check whether group
is an instance of Group.

In order to implement the actual alphabetization part, I added the
default ordering on name to the members association to both group and
meeting models.