### PR TITLE
Add feature specs

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,11 +1,12 @@
 FactoryGirl.define do
   factory :notification do
-    userid 1
+    association :user, factory: :user1
     uniqueid "MyString"
     data "MyText"
   end
   factory :group_member do
-    userid 1
+    association :user, factory: :user1
+    group
     leader false
 
     factory :group_leader do
@@ -14,7 +15,8 @@ FactoryGirl.define do
   end
 
   factory :meeting_member do
-    sequence(:userid)
+    association :user, factory: :user1
+    meeting
     leader false
   end
 

--- a/spec/features/user_visits_group_show_spec.rb
+++ b/spec/features/user_visits_group_show_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.feature "UserVisitsGroupsPages", type: :feature do
+  feature 'User vists groups page' do
+    scenario 'successfully' do
+      user = create :user1
+      login_as user
+      group = create :group_with_member, userid: user.id
+      meeting = create :meeting, groupid: group.id
+      create :meeting_member, userid: user.id, meetingid: meeting.id
+
+      visit group_path(group)
+
+      expect(page).to have_content group.name
+    end
+  end
+end

--- a/spec/features/user_visits_groups_pages_spec.rb
+++ b/spec/features/user_visits_groups_pages_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature "UserVisitsGroupsPages", type: :feature do
+  feature 'User vists groups page' do
+    scenario 'successfully' do
+      user = create :user1
+      login_as user
+      group = create :group_with_member, userid: user.id
+      ally = create :user2
+      create :allyships_accepted, user_id: user.id, ally_id: ally.id
+      available_group = create :group_with_member, userid: user.id
+
+      visit groups_path
+
+      expect(page).to have_content group.name
+      expect(page).to have_content available_group.name
+    end
+  end
+end

--- a/spec/models/group_member_spec.rb
+++ b/spec/models/group_member_spec.rb
@@ -13,13 +13,14 @@
 require 'rails_helper'
 
 describe GroupMember do
- 	it "creates a group member" do
- 		new_group = create(:group, description: 'Test Description')
- 		new_group_member = create(:group_member, groupid: new_group.id, leader: true)
-	  	expect(GroupMember.count).to eq(1)
- 	end
- 	it "does not create a group member" do
- 		new_group_member = build(:group_member, leader: true)
-	  	expect(new_group_member).to have(1).error_on(:groupid)
- 	end
+  it "has a valid factory" do
+    group_member = build :group_member
+    expect(group_member).to be_valid
+  end
+  context "when groupid is nil" do
+    it "is not valid" do
+      group_member = build :group_member, groupid: nil
+      expect(group_member).to have(1).error_on(:groupid)
+    end
+  end
 end

--- a/spec/models/meeting_member_spec.rb
+++ b/spec/models/meeting_member_spec.rb
@@ -13,16 +13,15 @@
 require 'rails_helper'
 
 describe MeetingMember do
- 	it "creates a meeting member" do
- 		new_group = create(:group, description: 'Test Description')
- 		new_meeting = create(:meeting, groupid: new_group.id, date: 'May 1, 2015')
- 		new_meeting_member = create(:meeting_member, meetingid: new_meeting.id, leader: true)
-	  	expect(MeetingMember.count).to eq(1)
- 	end
- 	it "does not create a meetin member" do
- 		new_group = create(:group, description: 'Test Description')
- 		new_meeting = create(:meeting, groupid: new_group.id, date: 'May 1, 2015')
- 		new_meeting_member = build(:meeting_member, leader: true)
-	  	expect(new_meeting_member).to have(1).error_on(:meetingid)
- 	end
+  it "has a valid factory" do
+    meeting_member = build :meeting_member
+    expect(meeting_member).to be_valid
+  end
+
+  context "when meetingid is nil" do
+    it "is invalid" do
+      meeting_member = build :meeting_member, meetingid: nil
+      expect(meeting_member).to have(1).error_on(:meetingid)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,8 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+include Warden::Test::Helpers
+Warden.test_mode!
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
This PR is two commits

The first adds associations to factories instead of using hard coded ids and updates the model specs that failed because of the change

The second configures warden so that it can be used in feature specs and adds two simple feature specs for groups/index and groups/show, which are just simple smoke tests that should hopefully catch any future changes that might cause the page to error