### PR TITLE
Setup default_params methods in moments and strategies controllers

### DIFF
--- a/app/controllers/moments_controller.rb
+++ b/app/controllers/moments_controller.rb
@@ -2,10 +2,26 @@ class MomentsController < ApplicationController
   before_filter :if_not_signed_in
   before_action :set_moment, only: [:show, :edit, :update, :destroy]
 
+  def default_params
+    @default_params ||= {
+      moment: {
+        category: [],
+        mood: [],
+        viewers: [],
+        strategies: []
+      }
+    }
+  end
+
   # GET /moments
   # GET /moments.json
   def index
-    @moments = Moment.where(:userid => current_user.id).all.order("created_at DESC").page(params[:page]).per($per_page)
+    name = params[:search]
+    if !name.blank?
+      @moments = Moment.where("name ilike ? AND userid = ?", "%#{name}%", current_user.id).all.order("created_at DESC").page(params[:page]).per($per_page)
+    else
+      @moments = Moment.where(:userid => current_user.id).all.order("created_at DESC").page(params[:page]).per($per_page)
+    end
     @page_title = "Moments"
     @page_new = new_moment_path
     @page_tooltip = "New moment"
@@ -319,6 +335,7 @@ class MomentsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def moment_params
+      params[:moment] = default_params[:moment].merge(params[:moment])
       params.require(:moment).permit(:name, :why, :fix, :userid, :comment, {:category => []}, {:mood => []}, {:viewers => []}, {:strategies => []})
     end
 

--- a/app/controllers/strategies_controller.rb
+++ b/app/controllers/strategies_controller.rb
@@ -2,10 +2,24 @@ class StrategiesController < ApplicationController
   before_filter :if_not_signed_in
   before_action :set_strategy, only: [:show, :edit, :update, :destroy]
 
+  def default_params
+    @default_params ||= {
+      strategy: {
+        viewers: [],
+        category: [],
+      }
+    }
+  end
+  
   # GET /strategies
   # GET /strategies.json
   def index
-    @strategies = Strategy.where(:userid => current_user.id).all.order("created_at DESC").page(params[:page]).per($per_page)
+    name = params[:search]
+    if !name.blank?
+      @strategies = Strategy.where("name ilike ? AND userid = ?", "%#{name}%", current_user.id).all.order("created_at DESC").page(params[:page]).per($per_page)
+    else
+      @strategies = Strategy.where(:userid => current_user.id).all.order("created_at DESC").page(params[:page]).per($per_page)
+    end
     @page_title = "Strategies"
     @page_new = new_strategy_path
     @page_tooltip = "New strategy"
@@ -315,6 +329,7 @@ class StrategiesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def strategy_params
+      params[:strategy] = default_params[:strategy].merge(params[:strategy]) 
       params.require(:strategy).permit(:name, :description, :userid, :comment, {:category => []}, {:viewers => []})
     end
 


### PR DESCRIPTION
 - Add default_params for use in merging default paramters that may be
missing in a request. Fixes #195 