### PR TITLE
Adding meeting_memberships association to group_member

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -182,14 +182,6 @@ class GroupsController < ApplicationController
         format.json { head :no_content }
       end
     else
-      # Remove corresponding meetings
-      meeting_members = MeetingMember.where(userid: memberid).all
-      meeting_members.each do |member|
-        if Meeting.where(id: member.meetingid, groupid: params[:groupid]).exists?
-          member.destroy
-        end
-      end
-
       group_member = GroupMember.find_by(userid: memberid, groupid: params[:groupid])
       group_member.destroy
 

--- a/app/models/group_member.rb
+++ b/app/models/group_member.rb
@@ -11,9 +11,22 @@
 #
 
 class GroupMember < ActiveRecord::Base
+  after_destroy :destroy_meeting_memberships
+
   validates_presence_of :groupid, :userid
   validates :leader, inclusion: [true, false]
 
   belongs_to :group, foreign_key: :groupid
   belongs_to :user, foreign_key: :userid
+
+  has_many :meetings, through: :group
+  has_many :meeting_memberships,
+           -> (group_member) { where(meeting_members: { userid: group_member.userid }) },
+           through: :meetings, source: :meeting_members
+
+  def destroy_meeting_memberships
+    # this can't be done through dependent: :destroy because nested associations
+    # are readonly
+    MeetingMember.where(id: meeting_membership_ids).destroy_all
+  end
 end

--- a/app/models/meeting_member.rb
+++ b/app/models/meeting_member.rb
@@ -16,4 +16,5 @@ class MeetingMember < ActiveRecord::Base
 
   belongs_to :meeting, foreign_key: :meetingid
   belongs_to :user, foreign_key: :userid
+  belongs_to :group_member, foreign_key: :userid
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,7 @@ class User < ActiveRecord::Base
   has_many :alerts, inverse_of: :user
   has_many :group_members, foreign_key: :userid
   has_many :groups, through: :group_members
+  has_many :meeting_members, foreign_key: :userid
 
   after_initialize :set_defaults, unless: :persisted?
 

--- a/spec/features/user_leaves_groups_spec.rb
+++ b/spec/features/user_leaves_groups_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.feature "UserLeavesGroups", type: :feature do
+  scenario "sucessfully" do
+    user = create :user1
+    login_as user
+    group = create :group_with_member, userid: user.id
+    other_group_member = create :user2
+    create :group_member, userid: other_group_member.id, groupid: group.id
+    visit groups_path
+
+    click_link "Leave"
+
+    expect(page).to have_content("You have left #{group.name}")
+  end
+end

--- a/spec/models/group_member_spec.rb
+++ b/spec/models/group_member_spec.rb
@@ -23,4 +23,30 @@ describe GroupMember do
       expect(group_member).to have(1).error_on(:groupid)
     end
   end
+
+  describe "#meeting_members" do
+    context "when it has associated meeting_memberships" do
+      it "returns the meeting_memberships" do
+        group_member = create :group_member
+        meeting = create :meeting, groupid: group_member.groupid
+        meeting_member = create :meeting_member, meetingid: meeting.id,
+          userid: group_member.userid
+
+        expect(group_member.meeting_memberships).to eq [meeting_member]
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "when it has associated meeting_members" do
+      it "destroys the meeting_memberships" do
+        group_member = create :group_member
+        meeting = create :meeting, groupid: group_member.groupid
+        meeting_member = create :meeting_member, meetingid: meeting.id,
+          userid: group_member.userid
+
+        expect { group_member.destroy }.to change(MeetingMember, :count).by(-1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Adding a callback to destroy all associated meeting memberships when a
group_membership is destroyed

I usually hesitate to add callbacks because they can get out of control
quickly but in this case it is really just a dependent: :destroy. I
couldn't do a real dependent: :destroy because it is a nested
association