### PR TITLE
Adding validation messages in groups/form

### DIFF
--- a/app/assets/javascripts/form_processing.js
+++ b/app/assets/javascripts/form_processing.js
@@ -62,10 +62,6 @@ var onReadyFormProcessing = function() {
 		  		emptyWhy = handleEmptyWhy(editor);
 		  	});
 		});
-
-		$('#new_group').submit(function() {
-			return complexCheck('group', emptyWhy);
-		});
 	}
 
 	if (newOrEdit(['meetings'])) {

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,8 +1,7 @@
 <%= form_for(@group) do |f| %>
   <% if @group.errors.any? %>
     <div class="error_explanation">
-      <h2><%= pluralize(@group.errors.count, 'error') %>
-        prohibited this group from being saved:</h2>
+      <h2>We can't save this group because: </h2>
       <ul>
         <% @group.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,9 +1,15 @@
 <%= form_for(@group) do |f| %>
-<% if @group.errors.any? %>
-  <div class="error_explanation">
-    <%= t('.error_explanation') %>
-  </div>
-<% end %>
+  <% if @group.errors.any? %>
+    <div class="error_explanation">
+      <h2><%= pluralize(@group.errors.count, 'error') %>
+        prohibited this group from being saved:</h2>
+      <ul>
+        <% @group.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 
 <% if action_name == "new" || action_name == "create" %>
   <div class="field">


### PR DESCRIPTION

![screenshot 2016-06-06 19 37 18](https://cloud.githubusercontent.com/assets/5423136/15842589/f8a85bc0-2c1f-11e6-87f7-490e4fb32679.png)
Before this commit, if you tried to submit new group without a
description, there was a JavaScript validation that prevented the form
from being submitted, but there was no error message, so it was
confusing why nothing was happening when 'Create Group' was clicked. By
removing this piece of JS and displaying the rails validation errors,
the user will be able to see why the group isn't sucessfully being
created.