### PR TITLE
User can activate email reminders for medications

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,5 +1,24 @@
 class NotificationMailer < ApplicationMailer
-	def notification_email(recipientid, data)
+  def take_medication(reminder)
+    @medication = reminder.medication
+    @user = @medication.user
+    mail(
+      to: @user.email,
+      subject: "Don't forget to take #{@medication.name}!"
+    )
+  end
+
+  def refill_medication(reminder)
+    @medication = reminder.medication
+    @user = @medication.user
+    mail(
+      to: @user.email,
+      subject: "Your refill for #{@medication.name} is coming up soon!"
+    )
+  end
+
+
+  def notification_email(recipientid, data)
 		@data = JSON.parse(data)
 		@recipient = User.where(id: recipientid).first
 		subject = 'if me | '

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,4 +1,6 @@
 class NotificationMailer < ApplicationMailer
+   default from: ENV["DEFAULT_FROM_ADDRESS"]
+
   def take_medication(reminder)
     @medication = reminder.medication
     @user = @medication.user

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -24,6 +24,11 @@ class Medication < ActiveRecord::Base
 
   belongs_to :user, foreign_key: :userid
 
+  has_one :take_medication_reminder
+  has_one :refill_reminder
+  accepts_nested_attributes_for :take_medication_reminder
+  accepts_nested_attributes_for :refill_reminder
+
   validates_presence_of :name, :dosage, :refill, :userid, :total, :strength, :dosage_unit, :total_unit, :strength_unit
 
   validates :dosage, :numericality => { :greater_than_or_equal_to => 0 }

--- a/app/models/refill_reminder.rb
+++ b/app/models/refill_reminder.rb
@@ -1,0 +1,5 @@
+class RefillReminder < ActiveRecord::Base
+  belongs_to :medication
+  validates_inclusion_of :active, in: [true, false]
+  scope :active, -> { where(active: true) }
+end

--- a/app/models/take_medication_reminder.rb
+++ b/app/models/take_medication_reminder.rb
@@ -1,0 +1,5 @@
+class TakeMedicationReminder < ActiveRecord::Base
+  belongs_to :medication
+  validates_inclusion_of :active, in: [true, false]
+  scope :active, -> { where(active: true) }
+end

--- a/app/services/medication_reminders.rb
+++ b/app/services/medication_reminders.rb
@@ -1,0 +1,26 @@
+class MedicationReminders
+  def send_take_medication_reminder_emails
+    TakeMedicationReminder.active.each do | reminder |
+      NotificationMailer.take_medication(reminder).deliver_now
+    end
+  end
+
+  def send_refill_reminder_emails
+    ready_for_refill.each do | reminder |
+      NotificationMailer.refill_medication(reminder).deliver_now
+    end
+  end
+
+  private
+
+  def ready_for_refill
+    RefillReminder.active.joins(:medication).where('medications.refill': one_week_from_now_as_string)
+  end
+
+  #Medication Refill dates are currently stored as strings in the database
+  #instead of timestamps. If we want to do more complicated reminders, we
+  #should migrate the data to timestamps.
+  def one_week_from_now_as_string
+    (Time.now + 1.week).strftime('%m/%d/%Y')
+  end
+end

--- a/app/views/medications/_form.html.erb
+++ b/app/views/medications/_form.html.erb
@@ -93,11 +93,36 @@
       </div>
       <%= f.text_field :refill %>
     </div>
+    
+    <%= f.fields_for :refill_reminder do | reminder | %>
+     <div class="inline-block">
+       <%= reminder.check_box(:active, { id: "refill_reminder" }, 'true', 'false') %>
+      <div class="label">
+        <%= reminder.label t('.refill_reminder'), for: 'refill_reminder' %>
+        <div class="align_right">
+          <span class="yes_title" title="We'll email you a reminder the week before your medication needs to be refilled"><i class="fa fa-question-circle"></i></span>
+        </div>
+        </div>
+        <div class="clear"></div>
+      </div>
+    <% end %>
 
+    <div class="field">
+      <%= f.fields_for :take_medication_reminder do | reminder | %>
+        <div class="inline-block">
+          <%= reminder.check_box(:active, { id: 'take_medication_reminder' }, 'true', 'false') %>
+         <div class="label">
+           <%= reminder.label t('.daily_reminder'), for: 'take_medication_reminder' %>
+          <div class="align_right">
+            <span class="yes_title" title="We'll email you a daily reminder to take this medication"><i class="fa fa-question-circle"></i></span>
+          </div>
+         </div>
+         <div class="clear"></div>
+        </div>
+      <% end %>
+    </div>
   </div>
-
 </div>
-
 <div class="align_right">
   <%= f.hidden_field :userid, :value => current_user.id %>
   <%= f.submit %>

--- a/app/views/notification_mailer/refill_medication.html.erb
+++ b/app/views/notification_mailer/refill_medication.html.erb
@@ -1,0 +1,7 @@
+<p>
+  Hi <%= @user.name %>,
+</p>
+<p>
+Here's a friendly reminder to refill your medication <%= @medication.name %> on 
+<%= @medication.refill %>!
+</p>

--- a/app/views/notification_mailer/refill_medication.text.erb
+++ b/app/views/notification_mailer/refill_medication.text.erb
@@ -1,0 +1,3 @@
+Hi <%= @user.name %>,
+Here's a friendly reminder to refill your medication <%= @medication.name %> on 
+<%= @medication.refill %>!

--- a/app/views/notification_mailer/take_medication.html.erb
+++ b/app/views/notification_mailer/take_medication.html.erb
@@ -1,0 +1,6 @@
+<p>
+  Hi <%= @user.name %>,
+</p>
+<p>
+  Here's a friendly reminder to take your medication: <%= @medication.name %>!
+</p>

--- a/app/views/notification_mailer/take_medication.text.erb
+++ b/app/views/notification_mailer/take_medication.text.erb
@@ -1,0 +1,2 @@
+Hi <%= @user.name %>,
+Here's a friendly reminder to take your medication: <%= @medication.name %>!

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -19,7 +19,7 @@ DEFAULT_FROM_ADDRESS: "yourmail@gmail.com"
 # Configuration values for Oauth through Google
 GOOGLE_CLIENT_ID: ""
 GOOGLE_CLIENT_SECRET: ""
-GOOGLE_APP_NAME: #this is the project name you configured when setting up your google client application
+GOOGLE_APP_NAME: "" #this is the project name you configured when setting up your google client application
 
 # Configuration values for pusher
 PUSHER_APP_ID: ""

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
-  
+  config.action_mailer.default_options = { sender: 'test@test.com' }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,10 +30,12 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  #
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,8 @@ en:
    dosage: 'dosage'
    dosage_placeholder: 'e.g. 2'
    refill: 'refill'
+   daily_reminder: 'Daily reminder email'
+   refill_reminder: 'Refill reminder email'
    error_explanation: 'Please fill out the marked fields!'
   index:
    subtitle: 'Keep track of your medications, including dosage and refill information.'

--- a/db/migrate/20160518220139_create_medication_reminders.rb
+++ b/db/migrate/20160518220139_create_medication_reminders.rb
@@ -1,0 +1,17 @@
+class CreateMedicationReminders < ActiveRecord::Migration
+  def change
+    create_table :take_medication_reminders do |t|
+      t.integer :medication_id, null: false
+      t.boolean :active, null:false
+
+      t.timestamps
+    end
+
+    create_table :refill_reminders do |t|
+      t.integer :medication_id, null: false
+      t.boolean :active, null:false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160516202831) do
+ActiveRecord::Schema.define(version: 20160518220139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,6 +138,13 @@ ActiveRecord::Schema.define(version: 20160516202831) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "refill_reminders", force: :cascade do |t|
+    t.integer  "medication_id", null: false
+    t.boolean  "active",        null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "strategies", force: :cascade do |t|
     t.integer  "userid"
     t.text     "category"
@@ -156,7 +163,14 @@ ActiveRecord::Schema.define(version: 20160516202831) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-  
+
+  create_table "take_medication_reminders", force: :cascade do |t|
+    t.integer  "medication_id", null: false
+    t.boolean  "active",        null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string   "email",                  limit: 255, default: "", null: false
     t.string   "encrypted_password",     limit: 255, default: "", null: false

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,11 @@
+namespace :scheduler do
+  desc "Send taking medication reminders"
+  task send_take_medication_reminders: :environment do
+    MedicationReminders.new.send_take_medication_reminder_emails
+  end
+
+  desc "Send refill reminders"
+  task send_refill_reminders: :environment do
+    MedicationReminders.new.send_refill_reminder_emails
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -94,6 +94,17 @@ FactoryGirl.define do
     description "Test Description"
   end
 
+  factory :medication do
+    name "Fancy Medication Name"
+    dosage 10
+    dosage_unit "tablet"
+    refill 01/01/2020
+    strength 12
+    strength_unit "mg"
+    total "30"
+    total_unit "tablets"
+  end
+
   factory :mood do
     name  "Test Mood"
     description "Test Mood"
@@ -109,6 +120,14 @@ FactoryGirl.define do
   factory :comment do
     comment_type "moment"
     comment "Test Comment"
+  end
+
+  factory :take_medication_reminder do
+    active true
+  end
+
+  factory :refill_reminder do
+    active true
   end
 
   factory :strategy do

--- a/spec/features/adding_medication_spec.rb
+++ b/spec/features/adding_medication_spec.rb
@@ -19,5 +19,26 @@ describe "user adds a new medication" do
     expect(page).to have_content("A medication name")
     new_medication = user.medications.last
     expect(new_medication.name).to eq("A medication name")
+    expect(new_medication.take_medication_reminder.active?).to eq(false)
+    expect(new_medication.refill_reminder.active?).to eq(false)
+  end
+
+  context "and turns on reminders" do
+    it "creates a new medication with reminders" do
+      fill_in "Name", with: "A medication name"
+      fill_in "medication_comments", with: "A comment"
+      fill_in "Strength", with: 100
+      fill_in "Total", with: 30
+      fill_in "Dosage", with: 2
+      fill_in "Refill", with: "05/25/2016"
+      find(:css, "#take_medication_reminder").set(true)
+      find(:css, "#refill_reminder").set(true)
+      click_on "Create Medication"
+      expect(page).to have_content("A medication name")
+      new_medication = user.medications.last
+      expect(new_medication.take_medication_reminder.active?).to eq(true)
+      expect(new_medication.refill_reminder.active?).to eq(true)
+    end
   end
 end
+

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,5 +1,27 @@
-require "rails_helper"
+require "spec_helper"
 
-RSpec.describe NotificationMailer, type: :mailer do
+describe "NotificationMailer" do
+  describe "#take_medication" do
+    let(:recipient) { FactoryGirl.create(:user1, email: "some@user.com") }
+    let!(:medication) { FactoryGirl.create(:medication, userid: recipient.id) }
+    let!(:reminder) { FactoryGirl.create(:take_medication_reminder, medication_id: medication.id) }
+    let(:mail) { NotificationMailer.take_medication(reminder) }
 
+    it "sends a reminder to a user" do
+      expect(mail.to).to eq(["some@user.com"])
+      expect(mail.subject).to eq("Don't forget to take Fancy Medication Name!")
+    end
+  end
+
+  describe "#refill_medication" do
+    let(:recipient) { FactoryGirl.create(:user1, email: "some@user.com") }
+    let!(:medication) { FactoryGirl.create(:medication, userid: recipient.id) }
+    let!(:reminder) { FactoryGirl.create(:take_medication_reminder, medication_id: medication.id) }
+    let(:mail) { NotificationMailer.refill_medication(reminder) }
+
+    it "sends a reminder to a user" do
+      expect(mail.to).to eq(["some@user.com"])
+      expect(mail.subject).to eq("Your refill for Fancy Medication Name is coming up soon!")
+    end
+  end
 end

--- a/spec/services/medication_reminders_spec.rb
+++ b/spec/services/medication_reminders_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+require "rails_helper"
+
+describe MedicationReminders do
+  let(:deliveries) { ActionMailer::Base.deliveries }
+
+  before { ActionMailer::Base.deliveries = [] }
+
+  describe "#send_take_medication_reminder_emails" do
+    context "no reminders" do
+      it "sends no emails" do
+        MedicationReminders.new.send_take_medication_reminder_emails
+        expect(deliveries.count).to eq(0)
+      end
+    end
+
+    context "reminders exist" do
+      let!(:user) { FactoryGirl.create(:user1) }
+      let!(:medication) { FactoryGirl.create(:medication, userid: user.id) }
+      let!(:reminder) { FactoryGirl.create(:take_medication_reminder, medication_id: medication.id) }
+
+      context "take medication reminder is active" do
+        it "sends an email" do
+          MedicationReminders.new.send_take_medication_reminder_emails
+          expect(deliveries.count).to eq(1)
+        end
+      end
+
+      context "take medication reminder is not active" do
+        it "doesn't send an email" do
+          reminder.update(active: false)
+          MedicationReminders.new.send_take_medication_reminder_emails
+          expect(deliveries.count).to eq(0)
+        end
+      end
+    end
+  end
+
+  describe "#send_refill_reminder_emails" do
+    context "no reminders" do
+      it "sends no emails" do
+        MedicationReminders.new.send_refill_reminder_emails
+        expect(deliveries.count).to eq(0)
+      end
+    end
+
+    context "reminders exist and it is one week before the refill" do
+      let!(:user) { FactoryGirl.create(:user1) }
+      let(:refill_date) { '01/01/2010' }
+      let!(:medication) { FactoryGirl.create(:medication, userid: user.id, refill: refill_date) }
+      let!(:reminder) { FactoryGirl.create(:refill_reminder, medication_id: medication.id) }
+
+      before "pretend its a week before the refill is happening" do
+        allow(Time).to receive(:now).and_return(Time.strptime(refill_date, '%m/%d/%Y') - 1.week)
+      end
+
+      context "refill reminder is active " do
+        it "sends an email" do
+          MedicationReminders.new.send_refill_reminder_emails
+          expect(deliveries.count).to eq(1)
+        end
+      end
+
+      context "refill reminder is not active" do
+        it "doesn't send an email" do
+          reminder.update(active: false)
+          MedicationReminders.new.send_refill_reminder_emails
+          expect(deliveries.count).to eq(0)
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This PR addresses #129.

A few things to consider:
- It doesn't look super beautiful, but with #112 coming down the pipeline, I figured there was more to be done when the medications tab is fancied up a bit.
- The emails will start to go out once we set up a scheduler on heroku for the two rake tasks `bundle exec rake scheduler:send_take_medication_reminders` & `bundle exec rake scheduler:send_refill_reminders`. I smoke tested these manually in my local environment (which is configured to send email out via gmail) but we can also test them on staging running those same commands from the command line.
- Refill reminders will go out a week before the refill date. If we want to make this functionality more configurable, we'll probably want to migrate away from storing these dates as strings and move them to timestamps.
- I'm open to feedback on the actual text of the emails themselves! They're pretty bare bones right now. 😄 

![screenshot 2016-06-15 18 18 25](https://cloud.githubusercontent.com/assets/5178170/16102584/a2425a26-3325-11e6-8f22-9f8850e0672b.png)

![screenshot 2016-06-15 18 18 43](https://cloud.githubusercontent.com/assets/5178170/16102588/a956caea-3325-11e6-8d21-a644e2a14ead.png)
