### PR TITLE
Fixes accessibility issue of having multiple h1 tags in the footer

### DIFF
--- a/app/assets/stylesheets/application/footer.scss
+++ b/app/assets/stylesheets/application/footer.scss
@@ -126,12 +126,13 @@
 	}
 }
 
-h1.footer_heading {
+.footer_heading {
 	font-weight: 300;
 	font-size: 30px;
 	padding: 0;
 	margin-top: 0;
 	margin-bottom: 20px;
+	display: block;
 	color: $header-text-color;
 	text-shadow: 0px 0px 20px $secondary-text-color;
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
 			<div class="table">
 				<div class="row">
 					<div class="table_cell large_padding_right">
-						<h1 class="footer_heading" id="if_me_links"><%= t('.app_name') %></h1>
+						<span class="footer_heading" id="if_me_links"><%= t('.app_name') %></span>
 						<%= link_to(t('.footer_about'), about_path) %>
 						<%= link_to(t('.footer_blog'), blog_path) %>
 						<%= link_to(t('.footer_contributors'), contributors_path) %>
@@ -11,7 +11,7 @@
 						<%= link_to(t('.footer_privacy'), privacy_path) %>
 					</div>
 					<div class="table_cell">
-						<h1 class="footer_heading" id="connect_links"><%= t('.connect') %></h1>
+						<span class="footer_heading" id="connect_links"><%= t('.connect') %></span>
 						<%= link_to(t('.github'), "https://github.com/julianguyen/ifme", target: "blank") %>
 						<%= link_to(t('.twitter'), "http://twitter.com/ifmeorg", target: "blank") %>
 						<%= link_to(t('.patreon'), 'http://patreon.com/ifme', target: "blank") %>


### PR DESCRIPTION
#224 

Hopefully fixes the above issue.  I have changed the `h1` tags in the footer to `span` tags and updated the footer.scss and _footer.html.erb respectively, but I have not compiled the scss, as I was not sure if this was done automatically in the asset pipeline, but the scss will need to be compiled.  Otherwise, I hope this fixes the issue - but eventually the "if me" branding at the top should probably be converted to an `h1` instead of a `span`.

I hope this helps!