### PR TITLE
Chore/add specs for allies controller

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper

--- a/spec/controllers/allies_controller_spec.rb
+++ b/spec/controllers/allies_controller_spec.rb
@@ -1,0 +1,174 @@
+describe AlliesController do
+  let(:user) { create(:user) }
+  let(:ally) { create(:user, name: 'Marco') }
+  let(:notification) { double(:notification) }
+
+  describe '#index' do
+    subject { get :index }
+
+    context 'when user is logged in' do
+      include_context :logged_in_user
+
+      it 'renders the correct template' do
+        expect(subject).to render_template(:index)
+      end
+
+      it 'sets the correct instance variables' do
+        incoming_ally = create(:user, name: 'Stella')
+        outgoing_ally = create(:user, name: 'Sam')
+
+        allow(user).to receive(:allies_by_status).with(:accepted).and_return([ally])
+        allow(user).to receive(:allies_by_status).with(:pending_from_user).and_return([incoming_ally])
+        allow(user).to receive(:allies_by_status).with(:pending_from_ally).and_return([outgoing_ally])
+
+        subject
+        expect(assigns(:page_search)).to eq true
+        expect(assigns(:accepted_allies)).to eq [ally]
+        expect(assigns(:incoming_ally_requests)).to eq [incoming_ally]
+        expect(assigns(:outgoing_ally_requests)).to eq [outgoing_ally]
+        expect(assigns(:page_title)).to eq 'Allies'
+      end
+    end
+
+    context 'when user is not logged in' do
+      before { subject }
+
+      it_behaves_like :with_no_logged_in_user
+    end
+  end
+
+  describe 'POST #add' do
+    context 'when user is logged in' do
+      include_context :logged_in_user
+
+      let(:notification_params) do
+        {
+          userid: ally.id.to_s,
+          uniqueid: "#{notification_type}_#{user.id}",
+          data: {
+            user: user.name,
+            userid: user.id,
+            uid: user.uid,
+            type: notification_type,
+            uniqueid: "#{notification_type}_#{user.id}"
+          }.to_json
+        }
+      end
+
+      subject { post :add, { ally_id: ally.id.to_s, format: :json } }
+
+      context 'with an existing ally request' do
+        let!(:allyship) { Allyship.create(user_id: user.id, ally_id: ally.id, status: :pending_from_ally) }
+        let!(:notification_type) { 'accepted_ally_request' }
+
+        it 'updates the allyship status to "accepted"' do
+          subject
+
+          expect(allyship.reload.status).to eq 'accepted'
+        end
+
+        it 'deletes the allyship request notification' do
+          allow(Notification).to receive(:find_by).and_return(notification)
+
+          expect(notification).to receive(:destroy)
+
+          subject
+        end
+
+        it 'creates an accepted allyship request notification' do
+          expect(Notification).to receive(:create).with(notification_params)
+
+          subject
+        end
+
+        it 'sends an email notification to the ally' do
+          data = {  
+              user: user.name,
+              userid: user.id,
+              uid: user.uid,
+              type: "#{notification_type}",
+              uniqueid: "#{notification_type}_#{user.id}"
+          }.to_json
+
+          allow(NotificationMailer).to receive(:notification_email).with(ally.id.to_s, data).and_return(notification)
+          expect(notification).to receive(:deliver_now)
+
+          subject
+        end
+      end
+
+      context 'with no existing allyship request' do
+        let(:notification_type) { 'new_ally_request' }
+
+        it 'creates a pending allyship request' do
+          expect(Allyship).to receive(:create).with({
+            user_id: user.id,
+            ally_id: ally.id.to_s,
+            status: 2
+          })
+        
+          subject
+        end
+
+        it 'creates a new allyship request notification' do
+          expect(Notification).to receive(:create).with(notification_params)
+        
+          subject
+        end
+      end
+    end
+
+    context 'when user is not logged in' do
+      before { post :add }
+
+      it_behaves_like :with_no_logged_in_user
+    end
+  end
+
+  describe 'DELETE #remove' do
+    let!(:allyship) { double(:allyship) }
+    subject { delete :remove, { ally_id: ally.id, format: :json } }
+
+    context 'when user is logged in' do
+      include_context :logged_in_user
+
+      it 'deletes the allyship' do
+        allow(Allyship).to receive(:find_by).and_return(allyship)
+        expect(allyship).to receive(:destroy)
+
+        subject
+      end
+
+      it 'deletes pertinent allyship request notifications' do
+        # Case 1: user terminating allyship did not initiate allyship
+        args = { userid: user.id, uniqueid: "new_ally_request_#{ally.id}" }
+        allow(Notification).to receive(:find_by).with(args).and_return(notification)
+        expect(notification).to receive(:destroy)
+
+        args = { userid: ally.id, uniqueid: "accepted_ally_request_#{user.id}" }
+        notification2 = double(:notification)
+        allow(Notification).to receive(:find_by).with(args).and_return(notification2)
+        expect(notification2).to receive(:destroy)
+
+        #Case 2: user terminating allyship did initiate allyship
+        args = { userid: ally.id, uniqueid: "new_ally_request_#{user.id}" }
+        notification3 = double(:notification)
+        allow(Notification).to receive(:find_by).with(args).and_return(notification3)
+        expect(notification3).to receive(:destroy)
+        
+        args = { userid: user.id, uniqueid: "accepted_ally_request_#{ally.id}" }
+        notification4 = double(:notification)
+        allow(Notification).to receive(:find_by).with(args).and_return(notification4)
+        expect(notification4).to receive(:destroy)
+
+        subject
+      end
+    end
+
+    context 'when user is not logged in' do
+      before { delete :remove }
+
+      it_behaves_like :with_no_logged_in_user
+    end
+  end
+end

--- a/spec/controllers/ally_controller_spec.rb
+++ b/spec/controllers/ally_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe AlliesController do
-
-end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ApplicationController do
 	describe "print_list_links" do
 		it "returns empty result for empty array" do

--- a/spec/controllers/moments_controller_spec.rb
+++ b/spec/controllers/moments_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe MomentsController do
 	describe "signed in" do
 		it "GET index" do

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe NotificationsController do
 
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SearchController do
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :user, class: 'User' do
+    sequence(:email) { |n| "some-email#{n}@ifme.org" }
+    password 'password'
+  end
+end

--- a/spec/features/adding_medication_spec.rb
+++ b/spec/features/adding_medication_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rails_helper"
 
 describe "user adds a new medication" do

--- a/spec/models/allyship_spec.rb
+++ b/spec/models/allyship_spec.rb
@@ -10,8 +10,6 @@
 #  status     :integer
 #
 
-require 'spec_helper'
-
 describe Allyship do
 	it "creates a valid ally relationship with accepted status" do
 	  new_user1 = create(:user1)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -12,8 +12,6 @@
 #  visibility   :string(255)
 #
 
-require 'spec_helper'
-
 describe Comment do
 	it "posts a valid comment" do
 	  new_user = create(:user1)

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -9,8 +9,6 @@
 #  description :text
 #
 
-require 'spec_helper'
-
 describe Group do
   it "creates a group" do
     new_group = create(:group, description: 'Test Description')

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -14,8 +14,6 @@
 #  date        :string(255)
 #
 
-require 'spec_helper'
-
 describe Meeting do
   it "has a valid factory" do
     result = build :meeting

--- a/spec/models/moment_spec.rb
+++ b/spec/models/moment_spec.rb
@@ -16,8 +16,6 @@
 #  strategies :text
 #
 
-require 'spec_helper'
-
 describe Moment do
 	describe "POST create" do
 		it "create private moment" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Notification do
   #pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/support_spec.rb
+++ b/spec/models/support_spec.rb
@@ -10,8 +10,6 @@
 #  updated_at   :datetime
 #
 
-require 'spec_helper'
-
 describe Support do
  	it "gives valid support to one moment" do
 	  new_user = create(:user1)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe User do
   describe ".find_for_google_oauth2" do
     let(:access_token) { 

--- a/spec/services/calendar_uploader_spec.rb
+++ b/spec/services/calendar_uploader_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe CalendarUploader do
   it "uploads an event to Google Calendar" do
     uploader = CalendarUploader.new(summary: "an exciting event", date: "2015/02/14", access_token: "a token", email: "an email")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include Devise::TestHelpers, :type => :controller
-
+  config.include StubCurrentUserHelper
   # ## Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:

--- a/spec/support/shared_contexts/logged_in_user.rb
+++ b/spec/support/shared_contexts/logged_in_user.rb
@@ -1,0 +1,6 @@
+shared_context :logged_in_user do
+  before do
+    stub_current_user_with(user)
+    allow(controller).to receive(:user_signed_in?).and_return(true)
+  end  
+end

--- a/spec/support/shared_examples/with_no_logged_in_user.rb
+++ b/spec/support/shared_examples/with_no_logged_in_user.rb
@@ -1,0 +1,5 @@
+shared_examples_for :with_no_logged_in_user do
+  it 'redirects to sign_in page' do
+    expect(response).to redirect_to new_user_session_path
+  end
+end


### PR DESCRIPTION
This PR:
  - [x] introduces test coverage for the three actions in the
    AlliesController (`:index`, `:add`, `:remove`)
  - [x] introduces a pattern for shared_contexts and shared_examples
  - [ ] ~~sets default url host on `test.rb` to enable testing of ActionMailer integrations~~
  - [x] includes `require 'spec_helper'` in `.rspec` to allow for spec composition without adding `require 'spec_helper'` every time.
  - [ ] ~~adds `pry-nav` gem to facilitate debugging in the test and development environments~~