### PR TITLE
Refactoring HeaderSpec tests - issue #180 

### DIFF
--- a/app/assets/javascripts/header.js
+++ b/app/assets/javascripts/header.js
@@ -15,7 +15,7 @@ var onReadyHeader = function() {
     }
   });
 
-  $('.expand_moment_button').mouseover(expandMomentMouseover);
+  $('.expand_moment_button').mouseover(click_flag,expandMomentMouseover);
 
   $('#header').mouseleave(headerMouseLeave);
 
@@ -73,7 +73,7 @@ function expandButton(event) {
   // even.data.value -> how many times was this function called?
   // if even number of times -> show expand_me
   // otherwise -> hide expand_me
-  if (event.data.value % 2 === 0) {
+  if (event.data.value % 2 == 0) {
     showExpandMe();
   } else {
     hideExpandMe();
@@ -89,12 +89,12 @@ function headerMouseLeave() {
   }
 }
 
-function expandMomentMouseover() {
+function expandMomentMouseover(click_flag) {
   if ($('#expand_moment').hasClass('display_none')) {
     showExpandMoment();
 
     if ($('#expand_me').hasClass('display_block')) {
-      click_flag++;
+      click_flag.value++;
     }
 
     hideExpandMe();

--- a/app/assets/javascripts/header.js
+++ b/app/assets/javascripts/header.js
@@ -73,7 +73,7 @@ function expandButton(event) {
   // even.data.value -> how many times was this function called?
   // if even number of times -> show expand_me
   // otherwise -> hide expand_me
-  if (event.data.value % 2 == 0) {
+  if (event.data.value % 2 === 0) {
     showExpandMe();
   } else {
     hideExpandMe();

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -42,6 +42,7 @@ describe("Header", function() {
 
     it("has called setHeight", function() {
       onReadyHeader();
+
       expect(setHeight).toHaveBeenCalled();
     });
 
@@ -53,14 +54,27 @@ describe("Header", function() {
       expect(showExpandMe).toHaveBeenCalled();
     });
 
-    it("toggles small_nav visibility", function (){
-      onReadyHeader();
-      $('#expand_nav').click();
-      $('#small_nav').addClass('display_none');
-      $('#expand_nav').click();
-      expect(showSmallTopNav).toHaveBeenCalled();
-      expect(hideSmallTopNav).toHaveBeenCalled();
-      expect(hideExpandMe).toHaveBeenCalled();
+    it("has called hideExpandMe when #expand_nav has been clicked", function() {
+        onReadyHeader();
+        $('#expand_nav').click();
+
+        expect(hideExpandMe).toHaveBeenCalled();
+    });
+
+    it("has called showSmallTopNav when #expand_nav has been clicked", function() {
+        $('#small_nav').addClass('display_none');
+
+        onReadyHeader();
+        $('#expand_nav').click();
+
+        expect(showSmallTopNav).toHaveBeenCalled();
+    });
+
+    it("has called hideSmallTopNav when #expand_nav has been clicked", function() {
+        onReadyHeader();
+        $('#expand_nav').click();
+
+        expect(hideSmallTopNav).toHaveBeenCalled();
     });
 
     it("handles expand_moment_button mouseover event", function() {
@@ -81,6 +95,7 @@ describe("Header", function() {
 
     it("calls setHeight() on window resize", function() {
       $(window).resize();
+
       expect(setHeight).toHaveBeenCalled();
     });
   });

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -122,16 +122,22 @@ describe("Header", function() {
       $('#small_nav').addClass('display_none');
     });
 
-    it("has changed small_nav class", function (){
-      showSmallTopNav();
-      expect($('#small_nav').hasClass('display_none')).toBeFalsy();
-      expect($('#small_nav').hasClass('display_block')).toBeTruthy();
+    it("has removed display_none class from small_nav", function() {
+        showSmallTopNav();
+
+        expect($('#small_nav').hasClass('display_none')).toBe(false);
     });
 
-    it("has set expand_nav capacity", function() {
+     it("has added display_block class to small_nav", function() {
+        showSmallTopNav();
+
+        expect($('#small_nav').hasClass('display_block')).toBe(true);
+    });
+
+    it("has changed expand_nav opacity amount to 0.8", function() {
       showSmallTopNav();
-      var expandNavOpacity = parseFloat($('#expand_nav').css('opacity')).toFixed(1);
-      expect(expandNavOpacity).toBe('0.8');
+
+      expect($('#expand_nav').css('opacity')).toBe('0.8');
     });
   });
 

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -181,18 +181,28 @@ describe("Header", function() {
       $('#expand_me').addClass('display_none');
     });
 
-    it("has changed expand_me class", function() {
+    it("has removed display_none from expandMe", function() {
       showExpandMe();
-      expect($('#expand_me').hasClass('display_none')).toBeFalsy();
-      expect($('#expand_me').hasClass('display_block')).toBeTruthy();
+
+      expect($('#expand_me').hasClass('display_none')).toBe(false);
     });
 
-    it("has set me and title_expand opacity", function() {
+    it("has added display_block from expandMe", function() {
       showExpandMe();
-      var meOpacity = parseFloat($('#me').css('opacity')).toFixed(1);
-      var titleExpandOpacity = parseFloat($('#title_expand').css('opacity')).toFixed(1);
-      expect(meOpacity).toBe('0.8');
-      expect(titleExpandOpacity).toBe('0.8');
+
+      expect($('#expand_me').hasClass('display_block')).toBe(true);
+    });
+
+    it("has changed #me opacity amount to 0.8", function() {
+      showExpandMe();
+
+      expect($('#me').css('opacity')).toBe('0.8');
+    });
+
+    it("has changed #title_expand opacity amount to 0.8", function() {
+      showExpandMe();
+
+      expect($('#title_expand').css('opacity')).toBe('0.8');
     });
   });
 

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -177,7 +177,6 @@ describe("Header", function() {
 
   describe("showExpandMe", function() {
     beforeEach(function () {
-      // adding the class to make sure showExpandMe gets rid of it
       $('#expand_me').addClass('display_none');
     });
 
@@ -187,7 +186,7 @@ describe("Header", function() {
       expect($('#expand_me').hasClass('display_none')).toBe(false);
     });
 
-    it("has added display_block from expandMe", function() {
+    it("has added display_block to expandMe", function() {
       showExpandMe();
 
       expect($('#expand_me').hasClass('display_block')).toBe(true);
@@ -208,11 +207,10 @@ describe("Header", function() {
 
   describe("showExpandMoment", function() {
     beforeEach(function (){
-      // adding the class to make sure showExpandMoment gets rid of it
       $('#expand_moment').addClass('display_none');
     });
 
-    it("has removed display_none to expand_moment", function() {
+    it("has removed display_none from expand_moment", function() {
       showExpandMoment();
 
       expect($('#expand_moment').hasClass('display_none')).toBe(false);
@@ -229,21 +227,32 @@ describe("Header", function() {
 
   describe("hideExpandMoment", function() {
     beforeEach(function() {
-      // adding the class to make sure hideExpandMe gets rid of it
       $('#expand_moment').addClass('display_block');
     });
 
-    it("has changed expand_moment class", function() {
-      hideExpandMoment();
-      expect($('#expand_moment').hasClass('display_block')).toBeFalsy();
-      expect($('#expand_moment').hasClass('display_none')).toBeTruthy();
+    it("has removed display_block from expand_moment", function() {
+        hideExpandMoment();
+
+        expect($('#expand_moment').hasClass('display_block')).toBe(false);
     });
 
-    it("has set moment and title_expand opacity", function() {
-      expect($('#moment').css('opacity')).toBe('1');
-      expect($('#title_expand').css('opacity')).toBe('1');
+    it("has added display_none to expand_moment", function() {
+        hideExpandMoment();
+
+        expect($('#expand_moment').hasClass('display_none')).toBe(true);
     });
 
+    it("has changed moment opacity amount to 1", function() {
+        hideExpandMoment();
+
+        expect($('#moment').css('opacity')).toBe('1');
+    });
+
+     it("has changed title_expand opacity amount to 1", function() {
+        hideExpandMoment();
+
+        expect($('#title_expand').css('opacity')).toBe('1');
+    });
 
   });
 

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -93,16 +93,25 @@ describe("Header", function() {
       $('#small_nav').addClass('display_block');
     });
 
-    it("has changed small_nav class", function (){
-      hideSmallTopNav();
-      expect($('#small_nav').hasClass('display_block')).toBeFalsy();
-      expect($('#small_nav').hasClass('display_none')).toBeTruthy();
+    it("has removed display_block class from small_nav", function() {
+
+        hideSmallTopNav();
+
+        expect($('#small_nav').hasClass('display_block')).toBe(false);
     });
 
-    it("has set expand_nav capacity", function() {
-      hideSmallTopNav();
-      var expandNavOpacity = parseFloat($('#expand_nav').css('opacity')).toFixed(1);
-      expect(expandNavOpacity ).toBe('1.0');
+    it("has added display_none class to small_nav", function() {
+
+        hideSmallTopNav();
+
+        expect($('#small_nav').hasClass('display_none')).toBe(true);
+    });
+
+     it("has changed expand_nav opacity amount to 1", function() {
+
+        hideSmallTopNav();
+
+         expect($('#expand_nav').css('opacity')).toBe('1');
     });
   });
 

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -254,8 +254,6 @@ describe("Header", function() {
 
   });
 
-
-
   describe("setHeight", function() {
     it("has set the height of header_space to 17", function() {
       $('#header').height(17);
@@ -265,6 +263,57 @@ describe("Header", function() {
       expect($('#header_space').height()).toBe(17);
 
     });
+  });
+
+  describe("expandButton", function() {
+
+    var click_flag;
+    var hideSmallTopNav;
+    var showExpandMe;
+    var hideExpandMe;
+    var setHeight;
+
+    beforeEach(function() {
+      click_flag = { value: 0 };
+      hideSmallTopNav = spyOn(window, 'hideSmallTopNav');
+      showExpandMe = spyOn(window, 'showExpandMe');
+      hideExpandMe = spyOn(window, 'hideExpandMe');
+      setHeight = spyOn(window, 'setHeight');
+    });
+
+    it("has called hideSmallTopNav", function() {
+        expandButton({ data: click_flag});
+
+        expect(hideSmallTopNav).toHaveBeenCalled();
+    });
+
+    it("has called showExpandMe when click_flag value is 0", function() {
+       expandButton({ data: click_flag});
+
+       expect(showExpandMe).toHaveBeenCalled();
+    });
+
+     it("has called hideExpandMe when click_flag value is not evenly divisble by 0", function() {
+       click_flag = 3;
+
+       expandButton({ data: click_flag});
+
+       expect(hideExpandMe).toHaveBeenCalled();
+    });
+
+     it("has called setHeight", function() {
+        expandButton({ data: click_flag});
+
+        expect(setHeight).toHaveBeenCalled();
+     });
+
+     it("has increased click_flag value by 1", function() {
+        expandButton({ data: click_flag});
+
+        expect(click_flag.value).toBe(1);
+     });
+
+
   });
 
 

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -1,9 +1,6 @@
 describe("Header", function() {
 
   beforeEach(function() {
-    // mocking the DOM
-    // "fresh" DOM will be created before
-    //  calling each describe()
     var elements = [];
     elements.push("<div id='expand_moment'></div>");
     elements.push("<div id='title_expand'></div>");
@@ -15,6 +12,7 @@ describe("Header", function() {
     elements.push("<div id='small_nav'></div>");
     elements.push("<div id='expand_nav'></div>");
     elements.push("<span class='expand_button'></span>");
+    elements.push("<a class='expand_moment_button'></a>");
     for (var i = 0; i < elements.length; i++) {
       $(document.body).append(elements[i]);
     }
@@ -29,6 +27,7 @@ describe("Header", function() {
      var showExpandMoment;
      var hideExpandMoment;
      var expandButton;
+     var expandMomentMouseover;
 
     beforeEach(function() {
         setHeight = spyOn(window, 'setHeight');
@@ -39,6 +38,7 @@ describe("Header", function() {
         showExpandMoment = spyOn(window, 'showExpandMoment');
         hideExpandMoment = spyOn(window, 'hideExpandMoment');
         expandButton = spyOn(window, 'expandButton');
+        expandMomentMouseover = spyOn(window, 'expandMomentMouseover');
     });
 
     it("has called setHeight", function() {
@@ -79,12 +79,11 @@ describe("Header", function() {
         expect(hideSmallTopNav).toHaveBeenCalled();
     });
 
-    it("handles expand_moment_button mouseover event", function() {
-      $("#expand_moment").addClass("display_none");
-      expandMomentMouseover();
-      expect(setHeight).toHaveBeenCalled();
-      expect(hideExpandMe).toHaveBeenCalled();
-      expect(showExpandMoment).toHaveBeenCalled();
+    it("has called expandMomentMouseover when expand_moment_button has been moused over", function() {
+        onReadyHeader();
+        $('.expand_moment_button').mouseover();
+
+        expect(expandMomentMouseover).toHaveBeenCalled();
     });
 
     it("calls hideExpandMoment() and setHeight() on $('#header').mouseleave", function() {

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -43,7 +43,7 @@ describe("Header", function() {
         headerMouseLeave = spyOn(window, 'headerMouseLeave');
     });
 
-    it("has called setHeight", function() {
+    it("has called setHeight when onReadyHeader has executed", function() {
       onReadyHeader();
 
       expect(setHeight).toHaveBeenCalled();
@@ -65,7 +65,7 @@ describe("Header", function() {
         expect(hideExpandMe).toHaveBeenCalled();
     });
 
-    it("has called showSmallTopNav when #expand_nav has been clicked", function() {
+    it("has called showSmallTopNav when small_nav has display_none as a class", function() {
         $('#small_nav').addClass('display_none');
 
         onReadyHeader();
@@ -74,21 +74,21 @@ describe("Header", function() {
         expect(showSmallTopNav).toHaveBeenCalled();
     });
 
-    it("has called hideSmallTopNav when #expand_nav has been clicked", function() {
+    it("has called hideSmallTopNav when display_none is not a class on small_nav", function() {
         onReadyHeader();
         $('#expand_nav').click();
 
         expect(hideSmallTopNav).toHaveBeenCalled();
     });
 
-    it("has called expandMomentMouseover", function() {
+    it("has called expandMomentMouseover when expand_moment_button is moused over", function() {
         onReadyHeader();
         $('.expand_moment_button').mouseover();
 
         expect(expandMomentMouseover).toHaveBeenCalled();
     });
 
-    it("has called headerMouseLeave", function() {
+    it("has called headerMouseLeave when header is moused over", function() {
         onReadyHeader();
         $('#header').mouseleave();
 
@@ -131,6 +131,7 @@ describe("Header", function() {
 
 
   describe("showSmallTopNav", function() {
+
     beforeEach(function() {
       $('#small_nav').addClass('display_none');
     });
@@ -291,7 +292,7 @@ describe("Header", function() {
       setHeight = spyOn(window, 'setHeight');
     });
 
-    it("has called hideSmallTopNav", function() {
+    it("has called hideSmallTopNav when expandButton is executed", function() {
         expandButton({ data: click_flag});
 
         expect(hideSmallTopNav).toHaveBeenCalled();
@@ -311,13 +312,13 @@ describe("Header", function() {
        expect(hideExpandMe).toHaveBeenCalled();
     });
 
-     it("has called setHeight", function() {
+     it("has called setHeight when expandButton is executed", function() {
         expandButton({ data: click_flag});
 
         expect(setHeight).toHaveBeenCalled();
      });
 
-     it("has increased click_flag value by 1", function() {
+     it("has increased click_flag value by 1 when expandButton is executed", function() {
         expandButton({ data: click_flag});
 
         expect(click_flag.value).toBe(1);
@@ -326,24 +327,23 @@ describe("Header", function() {
 
   describe("headerMouseLeave", function() {
     var hideExpandMoment;
+    var setHeight;
 
     beforeEach(function() {
       hideExpandMoment = spyOn(window, 'hideExpandMoment');
       setHeight = spyOn(window, 'setHeight');
-    });
-
-    it("has called hideExpandMoment", function() {
       $('#expand_moment').length = true;
       $('#expand_moment').addClass('display_block');
+    });
+
+    it("has called hideExpandMoment when expand_moment has a length and display_block class", function() {
 
       headerMouseLeave();
 
       expect(hideExpandMoment).toHaveBeenCalled();
     });
 
-    it("has called setHeight", function() {
-      $('#expand_moment').length = true;
-      $('#expand_moment').addClass('display_block');
+    it("has called setHeight when expand_moment has a length and display_block class", function() {
 
       headerMouseLeave();
 
@@ -362,14 +362,14 @@ describe("Header", function() {
             setHeight = spyOn(window, 'setHeight');
         });
 
-        it("has called showExpandMoment", function() {
+        it("has called showExpandMoment when expand_moment has a display_none class", function() {
             $('#expand_moment').addClass('display_none');
             expandMomentMouseover();
 
             expect(showExpandMoment).toHaveBeenCalled();
         });
 
-        it("has increased the value of click_flag by one", function() {
+        it("has increased the value of click_flag by 1 when expand_me has a display_block class", function() {
             var click_flag = { value : 1 };
             $('#expand_moment').addClass('display_none');
             $('#expand_me').addClass('display_block');
@@ -380,7 +380,7 @@ describe("Header", function() {
 
         });
 
-        it("has called hideExpandMe", function() {
+        it("has called hideExpandMe when expand_moment has a display_none class", function() {
             $('#expand_moment').addClass('display_none');
 
             expandMomentMouseover();
@@ -388,7 +388,7 @@ describe("Header", function() {
             expect(hideExpandMe).toHaveBeenCalled();
         });
 
-        it("has called setHeight", function() {
+        it("has called setHeight when expand_moment has a display_none class", function() {
             $('#expand_moment').addClass('display_none');
 
             expandMomentMouseover();

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -28,6 +28,7 @@ describe("Header", function() {
      var hideExpandMoment;
      var expandButton;
      var expandMomentMouseover;
+     var headerMouseLeave;
 
     beforeEach(function() {
         setHeight = spyOn(window, 'setHeight');
@@ -39,6 +40,7 @@ describe("Header", function() {
         hideExpandMoment = spyOn(window, 'hideExpandMoment');
         expandButton = spyOn(window, 'expandButton');
         expandMomentMouseover = spyOn(window, 'expandMomentMouseover');
+        headerMouseLeave = spyOn(window, 'headerMouseLeave');
     });
 
     it("has called setHeight", function() {
@@ -79,20 +81,29 @@ describe("Header", function() {
         expect(hideSmallTopNav).toHaveBeenCalled();
     });
 
-    it("has called expandMomentMouseover when expand_moment_button has been moused over", function() {
+    it("has called expandMomentMouseover", function() {
         onReadyHeader();
         $('.expand_moment_button').mouseover();
 
         expect(expandMomentMouseover).toHaveBeenCalled();
     });
 
-    it("calls hideExpandMoment() and setHeight() on $('#header').mouseleave", function() {
+    xit("calls hideExpandMoment() and setHeight() on $('#header').mouseleave", function() {
       $('#expand_moment').length = true;
       $('#expand_moment').addClass('display_block');
       headerMouseLeave();
       expect(setHeight).toHaveBeenCalled();
       expect(hideExpandMoment ).toHaveBeenCalled();
     });
+
+    it("has called headerMouseLeave", function() {
+        onReadyHeader();
+        $('#header').mouseleave();
+
+        expect(headerMouseLeave).toHaveBeenCalled();
+    });
+
+
 
     it("has called setHeight on window resize", function() {
       $(window).resize();

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -206,18 +206,22 @@ describe("Header", function() {
     });
   });
 
-
-
   describe("showExpandMoment", function() {
     beforeEach(function (){
       // adding the class to make sure showExpandMoment gets rid of it
       $('#expand_moment').addClass('display_none');
     });
 
-    it("has set the expand_moment class", function() {
+    it("has removed display_none to expand_moment", function() {
       showExpandMoment();
-      expect($('#expand_moment').hasClass('display_none')).toBeFalsy();
-      expect($('#expand_moment').hasClass('display_block')).toBeTruthy();
+
+      expect($('#expand_moment').hasClass('display_none')).toBe(false);
+    });
+
+    it("has added display_block to expand_moment", function() {
+      showExpandMoment();
+
+      expect($('#expand_moment').hasClass('display_block')).toBe(true);
     });
   });
 
@@ -239,6 +243,8 @@ describe("Header", function() {
       expect($('#moment').css('opacity')).toBe('1');
       expect($('#title_expand').css('opacity')).toBe('1');
     });
+
+
   });
 
 

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -14,12 +14,11 @@ describe("Header", function() {
     elements.push("<div id='expand_me'></div>");
     elements.push("<div id='small_nav'></div>");
     elements.push("<div id='expand_nav'></div>");
+    elements.push("<span class='expand_button'></span>");
     for (var i = 0; i < elements.length; i++) {
       $(document.body).append(elements[i]);
     }
   });
-
-
 
   describe("onReadyHeader", function() {
      var setHeight;
@@ -29,6 +28,7 @@ describe("Header", function() {
      var hideExpandMe;
      var showExpandMoment;
      var hideExpandMoment;
+     var expandButton;
 
     beforeEach(function() {
         setHeight = spyOn(window, 'setHeight');
@@ -38,6 +38,7 @@ describe("Header", function() {
         hideExpandMe = spyOn(window, 'hideExpandMe');
         showExpandMoment = spyOn(window, 'showExpandMoment');
         hideExpandMoment = spyOn(window, 'hideExpandMoment');
+        expandButton = spyOn(window, 'expandButton');
     });
 
     it("has called setHeight", function() {
@@ -46,12 +47,13 @@ describe("Header", function() {
       expect(setHeight).toHaveBeenCalled();
     });
 
-    it("toggles expand_me visibility", function (){
-      var click_flag = { value: 0 };
+    it("has called expandButton when clicked", function() {
+
       onReadyHeader();
-      expandButton({ data: click_flag });
-      expect(hideSmallTopNav).toHaveBeenCalled();
-      expect(showExpandMe).toHaveBeenCalled();
+
+      $('.expand_button').click();
+
+      expect(expandButton).toHaveBeenCalled();
     });
 
     it("has called hideExpandMe when #expand_nav has been clicked", function() {
@@ -93,7 +95,7 @@ describe("Header", function() {
       expect(hideExpandMoment ).toHaveBeenCalled();
     });
 
-    it("calls setHeight() on window resize", function() {
+    it("has called setHeight on window resize", function() {
       $(window).resize();
 
       expect(setHeight).toHaveBeenCalled();

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -142,25 +142,34 @@ describe("Header", function() {
   });
 
 
-
   describe("hideExpandMe", function() {
     beforeEach(function () {
       // adding the class to make sure hideExpandMe gets rid of it
       $('#expand_me').addClass('display_block');
     });
 
-    it("has changed expand_me class", function() {
-      hideExpandMe();
-      expect($('#expand_me').hasClass('display_block')).toBeFalsy();
-      expect($('#expand_me').hasClass('display_none')).toBeTruthy();
+     it("has removed display_block class from expand_me", function() {
+        hideExpandMe();
+
+        expect($('#expand_me').hasClass('display_block')).toBe(false);
     });
 
-    it("has set me and title_expand opacity", function() {
+    it("has added display_none class to expand_me", function() {
       hideExpandMe();
-      var meOpacity = parseInt($('#me').css('opacity'));
-      var titleExpandOpacity = parseInt($('#title_expand').css('opacity'))
-      expect(meOpacity).toBe(1);
-      expect(titleExpandOpacity).toBe(1);
+
+      expect($('#expand_me').hasClass('display_none')).toBe(true);
+    });
+
+     it("has changed #me opacity amount to 1", function() {
+      hideExpandMe();
+
+      expect($('#me').css('opacity')).toBe('1');
+    });
+
+     it("has changed title_expand opacity amount to 1", function() {
+      hideExpandMe();
+
+      expect($('#title_expand').css('opacity')).toBe('1');
     });
   });
 

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -223,8 +223,6 @@ describe("Header", function() {
     });
   });
 
-
-
   describe("hideExpandMoment", function() {
     beforeEach(function() {
       $('#expand_moment').addClass('display_block');
@@ -259,15 +257,13 @@ describe("Header", function() {
 
 
   describe("setHeight", function() {
-    it("has set the height of header_space", function() {
-      // testing for 2 arbitrarly chosen values
+    it("has set the height of header_space to 17", function() {
       $('#header').height(17);
+
       setHeight();
+
       expect($('#header_space').height()).toBe(17);
 
-      $('#header').height(24);
-      setHeight();
-      expect($('#header_space').height()).toBe(24);
     });
   });
 

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -88,22 +88,12 @@ describe("Header", function() {
         expect(expandMomentMouseover).toHaveBeenCalled();
     });
 
-    xit("calls hideExpandMoment() and setHeight() on $('#header').mouseleave", function() {
-      $('#expand_moment').length = true;
-      $('#expand_moment').addClass('display_block');
-      headerMouseLeave();
-      expect(setHeight).toHaveBeenCalled();
-      expect(hideExpandMoment ).toHaveBeenCalled();
-    });
-
     it("has called headerMouseLeave", function() {
         onReadyHeader();
         $('#header').mouseleave();
 
         expect(headerMouseLeave).toHaveBeenCalled();
     });
-
-
 
     it("has called setHeight on window resize", function() {
       $(window).resize();
@@ -112,11 +102,8 @@ describe("Header", function() {
     });
   });
 
-
-
   describe("hideSmallTopNav", function() {
     beforeEach(function() {
-      // adding the class to make sure shideSmallTopNav gets rid of it
       $('#small_nav').addClass('display_block');
     });
 
@@ -145,7 +132,6 @@ describe("Header", function() {
 
   describe("showSmallTopNav", function() {
     beforeEach(function() {
-      // adding the class to make sure showSmallTopNav gets rid of it
       $('#small_nav').addClass('display_none');
     });
 
@@ -171,7 +157,6 @@ describe("Header", function() {
 
   describe("hideExpandMe", function() {
     beforeEach(function () {
-      // adding the class to make sure hideExpandMe gets rid of it
       $('#expand_me').addClass('display_block');
     });
 
@@ -199,8 +184,6 @@ describe("Header", function() {
       expect($('#title_expand').css('opacity')).toBe('1');
     });
   });
-
-
 
   describe("showExpandMe", function() {
     beforeEach(function () {
@@ -341,6 +324,33 @@ describe("Header", function() {
      });
    });
 
+  describe("headerMouseLeave", function() {
+    var hideExpandMoment;
+
+    beforeEach(function() {
+      hideExpandMoment = spyOn(window, 'hideExpandMoment');
+      setHeight = spyOn(window, 'setHeight');
+    });
+
+    it("has called hideExpandMoment", function() {
+      $('#expand_moment').length = true;
+      $('#expand_moment').addClass('display_block');
+
+      headerMouseLeave();
+
+      expect(hideExpandMoment).toHaveBeenCalled();
+    });
+
+    it("has called setHeight", function() {
+      $('#expand_moment').length = true;
+      $('#expand_moment').addClass('display_block');
+
+      headerMouseLeave();
+
+      expect(setHeight).toHaveBeenCalled();
+    });
+  });
+
    describe("expandMomentMouseover", function() {
         var showExpandMoment;
         var hideExpandMe;
@@ -359,13 +369,15 @@ describe("Header", function() {
             expect(showExpandMoment).toHaveBeenCalled();
         });
 
-        xit("has increased the value of click_flag by one", function() {
+        it("has increased the value of click_flag by one", function() {
+            var click_flag = { value : 1 };
+            $('#expand_moment').addClass('display_none');
             $('#expand_me').addClass('display_block');
-            var click_flag = 1;
 
-            expandMomentMouseover();
+            expandMomentMouseover(click_flag);
 
-            expect(click_flag).toBe(2);
+            expect(click_flag.value).toBe(2);
+
         });
 
         it("has called hideExpandMe", function() {
@@ -385,8 +397,6 @@ describe("Header", function() {
         });
    });
 
-
-  // cleaning up mock DOM after each describe()
   afterEach(function (){
     $('#expand_moment').remove();
     $('#title_expand').remove();

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -312,9 +312,51 @@ describe("Header", function() {
 
         expect(click_flag.value).toBe(1);
      });
+   });
 
+   describe("expandMomentMouseover", function() {
+        var showExpandMoment;
+        var hideExpandMe;
+        var setHeight;
 
-  });
+        beforeEach(function() {
+            showExpandMoment = spyOn(window, 'showExpandMoment');
+            hideExpandMe = spyOn(window, 'hideExpandMe');
+            setHeight = spyOn(window, 'setHeight');
+        });
+
+        it("has called showExpandMoment", function() {
+            $('#expand_moment').addClass('display_none');
+            expandMomentMouseover();
+
+            expect(showExpandMoment).toHaveBeenCalled();
+        });
+
+        xit("has increased the value of click_flag by one", function() {
+            $('#expand_me').addClass('display_block');
+            var click_flag = 1;
+
+            expandMomentMouseover();
+
+            expect(click_flag).toBe(2);
+        });
+
+        it("has called hideExpandMe", function() {
+            $('#expand_moment').addClass('display_none');
+
+            expandMomentMouseover();
+
+            expect(hideExpandMe).toHaveBeenCalled();
+        });
+
+        it("has called setHeight", function() {
+            $('#expand_moment').addClass('display_none');
+
+            expandMomentMouseover();
+
+            expect(setHeight).toHaveBeenCalled();
+        });
+   });
 
 
   // cleaning up mock DOM after each describe()


### PR DESCRIPTION
This commit contains the following changes: 

- Change .toBeTruthy / .toBeFalsy assertions to .toBe(false) && .toBe(true)

- Refactor test names to use the following pattern : has  expected behavior When situation that behavior depends on

- Replace use of == with ===

- Refactor tests that have multiple assertions into multiple tests with singular assertions 

- Remove comments 

- Pass dependencies as arguments to functions to increase ease of testing 