### PR TITLE
Extracting GroupNotifier service object

### DIFF
--- a/app/services/group_notifier.rb
+++ b/app/services/group_notifier.rb
@@ -1,0 +1,50 @@
+class GroupNotifier
+  def initialize(group, type, current_user)
+    @group = group
+    @type = type
+    @current_user = current_user
+  end
+
+  def send_notifications_to(recipients)
+    recipients.each do |recipient|
+      create_notification(recipient)
+      push_notifications(recipient)
+      send_email_notification(recipient)
+    end
+  end
+
+  private
+
+  def send_email_notification(recipient)
+    NotificationMailer.notification_email(recipient.id, data).deliver_now
+  end
+
+  def push_notifications(recipient)
+    notifications = Notification.where(userid: recipient.id)
+                                .order('created_at ASC')
+    Pusher["private-#{recipient.id}"]
+      .trigger('new_notification', notifications: notifications)
+  end
+
+  def create_notification(recipient)
+    Notification.create(
+      userid: recipient.id,
+      uniqueid: uniqueid,
+      data: data
+    )
+  end
+
+  def data
+    JSON.generate(
+      user: @current_user.name,
+      groupid: @group.id,
+      group: @group.name,
+      type: @type,
+      uniqueid: uniqueid
+    )
+  end
+
+  def uniqueid
+    "#{@type}_#{@current_user.id}"
+  end
+end

--- a/spec/models/group_notifier_spec.rb
+++ b/spec/models/group_notifier_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe GroupNotifier, '#send_notifications_to' do
+  let(:group) { build_stubbed :group }
+  let(:type) { 'notification_type' }
+  let(:user) { build_stubbed :user1 }
+  let(:notifier) { GroupNotifier.new(group, type, user) }
+  let(:single_recipient) { build_stubbed :user1 }
+
+  it 'creates a notification for each recipient' do
+    stub_notification_mailer
+
+    recipients = build_stubbed_list :user1, 3
+    expect(Notification).to receive(:create).exactly(3).times
+
+    notifier.send_notifications_to(recipients)
+  end
+
+  it 'creates a notification with the correct userid, uniqueid and data' do
+    stub_notification_mailer
+
+    expect(Notification).to receive(:create).with(
+      userid: single_recipient.id,
+      uniqueid: "notification_type_#{user.id}",
+      data: expected_data
+    )
+
+    notifier.send_notifications_to([single_recipient])
+  end
+
+  it 'pushes notifications' do
+    stub_notification_mailer
+
+    notifications = double('notifications')
+    expect(Notification).to receive(:where)
+      .with(userid: single_recipient.id) { notifications }
+    allow(notifications).to receive(:order) { notifications }
+    pusher = double('pusher')
+    expect(Pusher).to receive(:[])
+      .with("private-#{single_recipient.id}") { pusher }
+    expect(pusher).to receive(:trigger)
+      .with('new_notification', notifications: notifications)
+
+    notifier.send_notifications_to([single_recipient])
+  end
+
+  it 'sends an email notification to the recipient' do
+    email = double('email')
+    expect(NotificationMailer).to receive(:notification_email)
+      .with(single_recipient.id, expected_data) { email }
+    expect(email).to receive(:deliver_now)
+
+    notifier.send_notifications_to([single_recipient])
+  end
+
+  def stub_notification_mailer
+    notification_email = double('notification_email')
+    allow(NotificationMailer).to receive(:notification_email) { notification_email }
+    allow(notification_email).to receive(:deliver_now)
+  end
+
+  def expected_data
+    JSON.generate(
+      user: user.name,
+      groupid: group.id,
+      group: group.name,
+      type: type,
+      uniqueid: "#{type}_#{user.id}"
+    )
+  end
+end


### PR DESCRIPTION
This change removes duplicated code in the join, update and create
methods of the groups_controller by extracting a service object to
notify the relevant members of each group.

Testing the GroupNotifier was a little messy because of how much
interaction there was with collaborators, so I ended up using a lot of
mocks.