### PR TITLE
Adding title helper

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,7 +8,6 @@ class GroupsController < ApplicationController
     @groups = current_user.groups
                           .includes(:group_members)
                           .order("groups.created_at DESC")
-    @page_title = "Groups"
     @page_tooltip = "New group"
     @page_new = new_group_path
     @available_groups = current_user.available_groups("groups.created_at DESC")
@@ -17,8 +16,6 @@ class GroupsController < ApplicationController
   # GET /groups/1
   # GET /groups/1.json
   def show
-    @page_title = @group.name
-
     if @group.members.include? current_user
       @meetings = @group.meetings.includes(:leaders)
     end
@@ -32,12 +29,10 @@ class GroupsController < ApplicationController
   # GET /groups/new
   def new
     @group = Group.new
-    @page_title = "New Group"
   end
 
   # GET /groups/1/edit
   def edit
-    @page_title = "Edit " + @group.name
     @group_members = GroupMember.where(groupid: @group.id).all
   end
 
@@ -45,7 +40,6 @@ class GroupsController < ApplicationController
   # POST /groups.json
   def create
     @group = Group.new(group_params)
-    @page_title = "New Group"
     respond_to do |format|
       if @group.save
         group_member = GroupMember.new(groupid: @group.id, userid: current_user.id, leader: true)
@@ -85,8 +79,6 @@ class GroupsController < ApplicationController
   # PATCH/PUT /groups/1
   # PATCH/PUT /groups/1.json
   def update
-    @page_title = 'Edit ' + @group.name
-
     respond_to do |format|
       if @group.update(group_params)
         update_leaders

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-	include LocalTimeHelper
+  include LocalTimeHelper
 
   def nav_link_to(body, url, html_options = {})
     environment = html_options[:method] ? {:method => html_options[:method]} : {}
@@ -31,5 +31,9 @@ module ApplicationHelper
       # New user registration with devise.
       (link_path == new_user_registration_path &&
        current_controller == "devise/registrations" && action_name == "create")
+  end
+
+  def title(page_title)
+    content_for(:title) { page_title }
   end
 end

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,1 +1,2 @@
+<% title 'Edit' + @group.name %>
 <%= render 'form' %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,3 +1,5 @@
+<% title 'Groups' %>
+
 <div class="subtitle">
   <%= t('.subtitle') %>
 </div>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,1 +1,2 @@
+<% title 'New Group' %>
 <%= render 'form' %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,3 +1,5 @@
+<% title @group.name %>
+
 <div class="group_info">
   <div class="small_margin_bottom">
     <%= raw(@group.description) %>

--- a/app/views/layouts/_title.html.erb
+++ b/app/views/layouts/_title.html.erb
@@ -1,0 +1,28 @@
+<%= t(:app_name) %>
+<% if current_page?(new_user_session_path) ||
+    (params[:controller] == "devise/sessions" && action_name == "new") %>
+  - Sign in
+<% elsif current_page?(new_user_registration_path) ||
+  (params[:controller] == "devise/registrations" && action_name == "create") %>
+- Sign up
+    <% elsif current_page?(new_user_password_path) ||
+      (params[:controller] == "devise/passwords" && action_name == "new") %>
+    - Forgot your password?
+  <% elsif current_page?(edit_user_registration_path) ||
+    (params[:controller] == "registrations" && action_name == "update") %>
+  - Account
+<% elsif current_page?(root_path) %>
+  - <%= t(:app_description) %>
+<% elsif current_page?(new_user_invitation_path) ||
+  (params[:controller] == "devise/invitations" && action_name == "new") ||
+  (params[:controller] == "users/invitations" && action_name == "create") %>
+  - <%= t('devise.invitations.new.header') %>
+<% elsif current_page?(accept_user_invitation_path) ||
+  (params[:controller] == "devise/invitations" && action_name == "accept") %>
+  - <%= t('devise.invitations.edit.header') %>
+<% elsif current_page?(edit_user_password_path) ||
+  (params[:controller] == "devise/passwords" && action_name == "edit") %>
+  - Reset your password
+<% else %>
+  - <%= yield(:title) || @page_title %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,194 +1,167 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<title>
-			<%= t(:app_name) %>
-			<% if current_page?(new_user_session_path) ||
-				(params[:controller] == "devise/sessions" && action_name == "new") %>
-				- Sign in
-			<% elsif current_page?(new_user_registration_path) ||
-				(params[:controller] == "devise/registrations" && action_name == "create") %>
-				- Sign up
-			<% elsif current_page?(new_user_password_path) ||
-				(params[:controller] == "devise/passwords" && action_name == "new") %>
-				- Forgot your password?
-			<% elsif current_page?(edit_user_registration_path) ||
-				(params[:controller] == "registrations" && action_name == "update") %>
-				- Account
-			<% elsif current_page?(root_path) %>
-				- <%= t(:app_description) %>
-			<% elsif current_page?(new_user_invitation_path) ||
-				(params[:controller] == "devise/invitations" && action_name == "new") ||
-				(params[:controller] == "users/invitations" && action_name == "create") %>
-				- <%= t('devise.invitations.new.header') %>
-			<% elsif current_page?(accept_user_invitation_path) ||
-				(params[:controller] == "devise/invitations" && action_name == "accept") %>
-				- <%= t('devise.invitations.edit.header') %>
-			<% elsif current_page?(edit_user_password_path) ||
-				(params[:controller] == "devise/passwords" && action_name == "edit") %>
-				- Reset your password
-			<% elsif !@page_title.blank? %>
-				- <%= @page_title %>
-			<% end %>
-		</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
-		<%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+  <head>
+    <title>
+      <%= render 'layouts/title' %>
+    </title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
 
-		<%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-		<%= csrf_meta_tags %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+    <%= csrf_meta_tags %>
 
-		<% if user_signed_in? %>
-		<!-- Pusher -->
-		<script src="https://js.pusher.com/3.0/pusher.min.js"></script>
-		<%= tag :meta, :name => "pusher-key", :content => ENV["PUSHER_KEY"] %>
-		<% end %>
+    <% if user_signed_in? %>
+      <!-- Pusher -->
+      <script src="https://js.pusher.com/3.0/pusher.min.js"></script>
+      <%= tag :meta, :name => "pusher-key", :content => ENV["PUSHER_KEY"] %>
+    <% end %>
 
-		<!-- jQuery UI -->
-		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
-		<link rel="stylesheet" href="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.10.3/themes/flick/jquery-ui.css" />
-		<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
-		<style type="text/css">
-			.ui-menu .ui-menu-item a,.ui-menu .ui-menu-item a.ui-state-hover, .ui-menu .ui-menu-item a.ui-state-active {
-				font-weight: normal;
-				margin: -1px;
-				text-align:left;
-				font-size:14px;
-				}
-			.ui-autocomplete-loading { background: white url("/assets/ui-anim_basic_16x16.gif") right center no-repeat; }
-		</style>
+    <!-- jQuery UI -->
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.10.3/themes/flick/jquery-ui.css" />
+    <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
+    <style type="text/css">
+.ui-menu .ui-menu-item a,.ui-menu .ui-menu-item a.ui-state-hover, .ui-menu .ui-menu-item a.ui-state-active {
+  font-weight: normal;
+  margin: -1px;
+  text-align:left;
+  font-size:14px;
+}
+      .ui-autocomplete-loading { background: white url("/assets/ui-anim_basic_16x16.gif") right center no-repeat; }
+    </style>
 
-		<!-- Timepicker UI -->
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js" type="text/javascript"></script>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.css" />
+    <!-- Timepicker UI -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-timepicker/1.10.0/jquery.timepicker.min.css" />
 
-		<!-- Timezone Detection -->
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.6/jstz.min.js" type="text/javascript"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js" type="text/javascript"></script>
-	</head>
+    <!-- Timezone Detection -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.6/jstz.min.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js" type="text/javascript"></script>
+  </head>
 
-	<body class="<%= controller_name %> <%= action_name %>">
-		<div id="notifications" class="display_none">
-			<div id="notifications_text">
-				<div class="table">
-					<div class="table_row">
-						<div class="table_cell vertical_align_middle">
-							<h1 class="notification_name">Notifications</h1>
-						</div>
-						<div class="table_cell align_right">
-							<h1 id="clear_notifcations" class="align_left small_margin_right">Clear</h1>
-							<h1 id="close_notifications" class="align_right"><i class="fa fa-times"></i></h1>
-							<div class="clear"></div>
-						</div>
-					</div>
-				</div>
-				<i id="notifications_none" class="display_none">There are none</i>
-				<div id="notifications_list"></div>
-			</div>
-		</div>
+  <body class="<%= controller_name %> <%= action_name %>">
+    <div id="notifications" class="display_none">
+      <div id="notifications_text">
+        <div class="table">
+          <div class="table_row">
+            <div class="table_cell vertical_align_middle">
+              <h1 class="notification_name">Notifications</h1>
+            </div>
+            <div class="table_cell align_right">
+              <h1 id="clear_notifcations" class="align_left small_margin_right">Clear</h1>
+              <h1 id="close_notifications" class="align_right"><i class="fa fa-times"></i></h1>
+              <div class="clear"></div>
+            </div>
+          </div>
+        </div>
+        <i id="notifications_none" class="display_none">There are none</i>
+        <div id="notifications_list"></div>
+      </div>
+    </div>
 
-		<div id="container">
-			<%= render partial: "shared/header" %>
+    <div id="container">
+      <%= render partial: "shared/header" %>
 
-			<div class="page-container">
+      <div class="page-container">
 
-				<div id="header_space"></div>
+        <div id="header_space"></div>
 
-				<div id="page_title">
-				<div class="overlay">
+        <div id="page_title">
+          <div class="overlay">
 
-					<div id="page_title_content">
-						<% if current_page?(new_user_session_path) ||
-						(params[:controller] == "devise/sessions" && action_name == "new") %>
-							<%= t('.signin') %>
+            <div id="page_title_content">
+              <% if current_page?(new_user_session_path) ||
+                  (params[:controller] == "devise/sessions" && action_name == "new") %>
+                <%= t('.signin') %>
 
-						<% elsif current_page?(new_user_registration_path) ||
-						(params[:controller] == "devise/registrations" && action_name == "create") %>
-							<%= t('.create_account') %>
+              <% elsif current_page?(new_user_registration_path) ||
+                (params[:controller] == "devise/registrations" && action_name == "create") %>
+              <%= t('.create_account') %>
 
-						<% elsif current_page?(new_user_password_path) ||
-						(params[:controller] == "devise/passwords" && action_name == "new") %>
-							<%= t('.forgot_password') %>
+            <% elsif current_page?(new_user_password_path) ||
+              (params[:controller] == "devise/passwords" && action_name == "new") %>
+            <%= t('.forgot_password') %>
 
-						<% elsif current_page?(edit_user_registration_path) ||
-						(params[:controller] == "registrations" && action_name == "update") %>
-							<%= t('.update_account') %>
+          <% elsif current_page?(edit_user_registration_path) ||
+            (params[:controller] == "registrations" && action_name == "update") %>
+          <%= t('.update_account') %>
 
-						<% elsif !@page_edit.blank? %>
-							<div class="align_left">
-								<%= @page_title %>
-							</div>
-							<div class="align_right">
-								<%= link_to(raw('<i class="fa fa-pencil"></i>'), @page_edit, class: 'page_edit yes_title', title: @page_tooltip) %>
-							</div>
-							<div class="clear"></div>
+        <% elsif !@page_edit.blank? %>
+          <div class="align_left">
+            <%= @page_title %>
+          </div>
+          <div class="align_right">
+            <%= link_to(raw('<i class="fa fa-pencil"></i>'), @page_edit, class: 'page_edit yes_title', title: @page_tooltip) %>
+          </div>
+          <div class="clear"></div>
 
-						<% elsif !@page_new.blank? %>
-							<div class="align_left">
-								<%= @page_title %>
-							</div>
-							<div class="align_right">
-							<%= link_to(raw('<i class="fa fa-plus-circle"></i>'), @page_new, class: 'page_new yes_title', title: @page_tooltip) %>
-							</div>
-							<div class="clear"></div>
+        <% elsif !@page_new.blank? %>
+          <div class="align_left">
+            <%= @page_title %>
+          </div>
+          <div class="align_right">
+            <%= link_to(raw('<i class="fa fa-plus-circle"></i>'), @page_new, class: 'page_new yes_title', title: @page_tooltip) %>
+          </div>
+          <div class="clear"></div>
 
-						<% elsif !@page_author.blank? %>
-							<div id="other_user">
-								<div class="align_left">
-									<%= @page_title %>
-								</div>
-								<div class="align_right">
-									<%= @page_author %>
-								</div>
-								<div class="clear"></div>
-							</div>
-						<% elsif current_page?(root_path) && !user_signed_in? %>
-							<div class="headline center">
-						        <span class="branding_title">
-						          <%= t('.if') %> <span class="branding_subtitle"><%= t('.me') %></span>
-						        </span><%= t(:app_description) %>
-					      </div>
-					    <% elsif current_page?(new_user_invitation_path) ||
-							(params[:controller] == "devise/invitations" && action_name == "new") ||
-							(params[:controller] == "users/invitations" && action_name == "create") %>
-							<%= t('devise.invitations.new.header') %>
-						<% elsif current_page?(accept_user_invitation_path) ||
-							(params[:controller] == "devise/invitations" && action_name == "accept") %>
-							<%= t('devise.invitations.edit.header') %>
-						<% elsif current_page?(edit_user_password_path) ||
-							(params[:controller] == "devise/passwords" && action_name == "edit") %>
-							Reset your password
-						<% else %>
-							<%= @page_title %>
-						<% end %>
-					</div>
+        <% elsif !@page_author.blank? %>
+          <div id="other_user">
+            <div class="align_left">
+              <%= @page_title %>
+            </div>
+            <div class="align_right">
+              <%= @page_author %>
+            </div>
+            <div class="clear"></div>
+          </div>
+        <% elsif current_page?(root_path) && !user_signed_in? %>
+          <div class="headline center">
+            <span class="branding_title">
+              <%= t('.if') %> <span class="branding_subtitle"><%= t('.me') %></span>
+            </span><%= t(:app_description) %>
+        </div>
+      <% elsif current_page?(new_user_invitation_path) ||
+        (params[:controller] == "devise/invitations" && action_name == "new") ||
+        (params[:controller] == "users/invitations" && action_name == "create") %>
+      <%= t('devise.invitations.new.header') %>
+    <% elsif current_page?(accept_user_invitation_path) ||
+      (params[:controller] == "devise/invitations" && action_name == "accept") %>
+    <%= t('devise.invitations.edit.header') %>
+  <% elsif current_page?(edit_user_password_path) ||
+    (params[:controller] == "devise/passwords" && action_name == "edit") %>
+  Reset your password
+<% else %>
+  <%= @page_title %>
+<% end %>
+            </div>
 
-				</div>
-				</div>
+          </div>
+        </div>
 
-				<div id="content">
-					<% if !notice.blank? %>
-						<% if current_page?(root_path) %>
-							<div class="notice display_none"><%= notice %></div>
-						<% else %>
-							<div class="notice"><%= notice %></div>
-						<% end %>
-					<% end %>
+        <div id="content">
+          <% if !notice.blank? %>
+            <% if current_page?(root_path) %>
+              <div class="notice display_none"><%= notice %></div>
+            <% else %>
+              <div class="notice"><%= notice %></div>
+            <% end %>
+          <% end %>
 
-					<% if !alert.blank? %>
-						<% if current_page?(root_path) %>
-							<div class="alert display_none"><%= alert %></div>
-						<% else %>
-							<div class="alert"><%= alert %></div>
-						<% end %>
-					<% end %>
+          <% if !alert.blank? %>
+            <% if current_page?(root_path) %>
+              <div class="alert display_none"><%= alert %></div>
+            <% else %>
+              <div class="alert"><%= alert %></div>
+            <% end %>
+          <% end %>
 
-					<%= yield %>
-				</div>
+          <%= yield %>
+        </div>
 
-				<%= render partial: "shared/footer" %>
-			</div>
-		</div>
-	</body>
+        <%= render partial: "shared/footer" %>
+      </div>
+    </div>
+  </body>
 </html>

--- a/spec/features/user_visits_group_show_spec.rb
+++ b/spec/features/user_visits_group_show_spec.rb
@@ -11,7 +11,8 @@ RSpec.feature "UserVisitsGroupsPages", type: :feature do
 
       visit group_path(group)
 
-      expect(page).to have_content group.name
+      expect(page.title).to match group.name
+      expect(page).to have_content group.description
     end
   end
 end


### PR DESCRIPTION
Before this commit, @page_title was being set in the controller so that the
value was accessible in the application layout. IMO the logic for
setting the title really belongs in the view instead of the controller.
[This Railscast](http://railscasts.com/episodes/30-pretty-page-title?autoplay=true) shows a clever way to do this through an application helper method. This commit
implements this helper and uses it for all groups views. I was thinking
we could slowly update the rest of the views, but for now the layout
falls back to @page_title if title isn't set in the view.