### PR TITLE
Using built-in :authenticate_user! before_action

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < ApplicationController
-  before_filter :if_not_signed_in
+  before_action :authenticate_user!
   before_action :set_group, only: [:show, :edit, :update, :destroy]
 
   # GET /groups
@@ -191,15 +191,6 @@ class GroupsController < ApplicationController
 
   def group_member_params
     params.permit(:groupid).merge(userid: current_user.id, leader: false)
-  end
-
-  def if_not_signed_in
-    if !user_signed_in?
-      respond_to do |format|
-        format.html { redirect_to new_user_session_path }
-        format.json { head :no_content }
-      end
-    end
   end
 
   def update_leaders

--- a/spec/support/stub_current_user.rb
+++ b/spec/support/stub_current_user.rb
@@ -1,6 +1,6 @@
 module StubCurrentUserHelper
   def stub_current_user_with(user)
-    allow(controller).to receive(:user_signed_in?).and_return(true)
+    allow(request.env['warden']).to receive(:authenticate!).and_return(user)
     allow(controller).to receive(:current_user).and_return(user)
   end
 


### PR DESCRIPTION
The user_signed_in method duplicated the functionality of
the authenticate_user! helper provided by Devise. The authenticate_user!
method also also provides a flash 'You need to sign in before continuing',
so I think it's better to just use that.

This change initially caused the controller specs to fail because the
stub_current_user wasn't effectively stubbing the authentication, so I
tweaked the method using the example
[here](https://github.com/plataformatec/devise/wiki/How-To:-Stub-authentication-in-controller-specs)