### PR TITLE
Adding after_destroy callback to destroy notifications

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -127,13 +127,6 @@ class GroupsController < ApplicationController
   def destroy
     @group.destroy
 
-    # Delete notifications for this group
-    Notification.where("uniqueid ilike ?", "%new_group%").all.each do |notification|
-      if JSON.parse(notification.data)["groupid"].to_i == @group.id.to_i
-        notification.destroy
-      end
-    end
-
     respond_to do |format|
       format.html { redirect_to groups_path }
       format.json { head :no_content }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -19,7 +19,21 @@ class Group < ActiveRecord::Base
   has_many :leaders, -> { where(group_members: { leader: true }) },
            through: :group_members, source: :user
 
+  after_destroy :destroy_notifications
+
   def led_by?(user)
     leaders.include? user
+  end
+
+  def notifications
+    Notification.where('uniqueid ilike ?', '%new_group%').select do |n|
+      JSON.parse(n.data)['groupid'].to_i == id
+    end
+  end
+
+  private
+
+  def destroy_notifications
+    notifications.each(&:destroy)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -10,4 +10,5 @@
 
 class Notification < ActiveRecord::Base
   validates_presence_of :userid, :uniqueid, :data
+  belongs_to :user, foreign_key: :userid
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,7 @@ class User < ActiveRecord::Base
   has_many :groups, through: :group_members
   has_many :meeting_members, foreign_key: :userid
   has_many :medications, foreign_key: :userid
+  has_many :notifications, foreign_key: :userid
   after_initialize :set_defaults, unless: :persisted?
 
   def remove_leading_trailing_whitespace

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -101,5 +101,28 @@ describe Group do
 
       expect { @group.destroy }.to change(MeetingMember, :count).by(-1)
     end
+
+    it 'destroys associated notifications' do
+      group = create :group
+      create_notification_for(group)
+
+      expect { group.destroy }.to change(Notification, :count).by(-1)
+    end
+  end
+
+  describe '#notifications' do
+    it 'returns the notifications with a uniqueid contiaining "new_group"' do
+      group = build_stubbed :group
+      notification = create_notification_for(group)
+
+      result = group.notifications
+
+      expect(result).to eq [notification]
+    end
+  end
+
+  def create_notification_for(group)
+    data = { groupid: group.id }.to_json
+    create :notification, uniqueid: 'new_group_1', data: data
   end
 end


### PR DESCRIPTION
Ideally we could have a dependent: :delete_all association on group, but
I couldn't quite figure out how to define the has_and_belongs_to
association because the groupid is in the json string in the data field,
so I implemented it manually, defining group#notifications and an
after_destroy callback.