### PR TITLE
Refactoring update_leaders method

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -147,23 +147,9 @@ class GroupsController < ApplicationController
   end
 
   def update_leaders
-    return if params[:group][:leader].nil?
+    updated_leader_ids = params[:group][:leader]
+    return if updated_leader_ids.nil?
 
-    updated_leader_ids = params[:group][:leader].map(&:to_i)
-    current_leader_ids = @group.leader_ids
-
-    leaders_to_add = updated_leader_ids - current_leader_ids
-    leaders_to_remove = current_leader_ids - updated_leader_ids
-
-    update_leader_status(leaders_to_add)
-    update_leader_status(leaders_to_remove, false)
-  end
-
-  def update_leader_status(leaders, leader = true)
-    return if leaders.empty?
-    @group.group_members.where(userid: leaders).update_all(leader: leader)
-    pusher_type = leader ? 'add_group_leader' : 'remove_group_leader'
-    GroupNotifier.new(@group, pusher_type, current_user)
-                 .send_notifications_to(@group.leaders)
+    LeaderUpdater.new(@group, updated_leader_ids.map(&:to_i)).update
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -148,17 +148,22 @@ class GroupsController < ApplicationController
 
   def update_leaders
     return if params[:group][:leader].nil?
-    @group.group_members.each do |group_member|
-      if params[:group][:leader].include? group_member.userid.to_s
-        group_member.update(leader: true)
-        pusher_type = 'add_group_leader'
-      else
-        group_member.update(leader: false)
-        pusher_type = 'remove_group_leader'
-      end
 
-      GroupNotifier.new(@group, pusher_type, current_user)
-                   .send_notifications_to(@group.leaders)
-    end
+    updated_leader_ids = params[:group][:leader].map(&:to_i)
+    current_leader_ids = @group.leader_ids
+
+    leaders_to_add = updated_leader_ids - current_leader_ids
+    leaders_to_remove = current_leader_ids - updated_leader_ids
+
+    update_leader_status(leaders_to_add)
+    update_leader_status(leaders_to_remove, false)
+  end
+
+  def update_leader_status(leaders, leader = true)
+    return if leaders.empty?
+    @group.group_members.where(userid: leaders).update_all(leader: leader)
+    pusher_type = leader ? 'add_group_leader' : 'remove_group_leader'
+    GroupNotifier.new(@group, pusher_type, current_user)
+                 .send_notifications_to(@group.leaders)
   end
 end

--- a/app/services/leader_updater.rb
+++ b/app/services/leader_updater.rb
@@ -1,0 +1,47 @@
+class LeaderUpdater
+  def initialize(group, updated_leader_ids)
+    @group = group
+    @updated_leader_ids = updated_leader_ids
+    @leader_ids_before_update = group.leader_ids
+  end
+
+  def update
+    remove_former_leaders
+    add_new_leaders
+
+    notify_leaders(former_leader_userids, 'remove_group_leader')
+    notify_leaders(new_leader_userids, 'add_group_leader')
+  end
+
+  private
+
+  def add_new_leaders
+    group_memberships_for(new_leader_userids)
+      .update_all(leader: true)
+  end
+
+  def remove_former_leaders
+    group_memberships_for(former_leader_userids)
+      .update_all(leader: false)
+  end
+
+  def notify_leaders(user_ids, pusher_type)
+    leaders_before_update = User.where(id: @leader_ids_before_update)
+    User.where(id: user_ids).each do |user|
+      GroupNotifier.new(@group, pusher_type, user)
+                   .send_notifications_to(leaders_before_update)
+    end
+  end
+
+  def group_memberships_for(user_ids)
+    @group.group_members.where(userid: user_ids)
+  end
+
+  def former_leader_userids
+    @leader_ids_before_update - @updated_leader_ids
+  end
+
+  def new_leader_userids
+    @updated_leader_ids - @leader_ids_before_update
+  end
+end

--- a/app/services/leader_updater.rb
+++ b/app/services/leader_updater.rb
@@ -26,10 +26,9 @@ class LeaderUpdater
   end
 
   def notify_leaders(user_ids, pusher_type)
-    leaders_before_update = User.where(id: @leader_ids_before_update)
     User.where(id: user_ids).each do |user|
       GroupNotifier.new(@group, pusher_type, user)
-                   .send_notifications_to(leaders_before_update)
+                   .send_notifications_to(@group.leaders)
     end
   end
 

--- a/spec/features/user_updates_groups_spec.rb
+++ b/spec/features/user_updates_groups_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.feature 'UserUpdatesGroups', type: :feature do
+  scenario 'leader removes another leader' do
+    leader = create :user1
+    login_as leader
+    other_leader = create :user2
+    group = create :group
+    create :group_member, user: leader, group: group, leader: true
+    create :group_member, user: other_leader, group: group, leader: true
+
+    visit edit_group_path(group)
+    uncheck "group_leader_#{other_leader.id}"
+    click_button 'Update Group'
+
+    expect(group.leaders).to eq [leader]
+  end
+
+  scenario 'leader adds another leader' do
+    leader = create :user1
+    login_as leader
+    other_user = create :user2
+    group = create :group
+    create :group_member, user: leader, group: group, leader: true
+    create :group_member, user: other_user, group: group, leader: false
+
+    visit edit_group_path(group)
+    check "group_leader_#{other_user.id}"
+    click_button 'Update Group'
+
+    expect(group.leaders).to include(other_user)
+  end
+end

--- a/spec/services/leader_updater_spec.rb
+++ b/spec/services/leader_updater_spec.rb
@@ -11,7 +11,7 @@ describe LeaderUpdater, '#update' do
     expect(GroupNotifier).to receive(:new)
       .with(group, 'remove_group_leader', other_leader).and_return(notifier)
     expect(notifier).to receive(:send_notifications_to)
-      .with([leader, other_leader])
+      .with([leader])
 
     LeaderUpdater.new(group, [leader.id]).update
 
@@ -27,7 +27,7 @@ describe LeaderUpdater, '#update' do
     notifier = double('notifier')
     expect(GroupNotifier).to receive(:new)
       .with(group, 'add_group_leader', non_leader).and_return(notifier)
-    expect(notifier).to receive(:send_notifications_to).with([leader])
+    expect(notifier).to receive(:send_notifications_to).with([leader, non_leader])
 
     LeaderUpdater.new(group, [leader.id, non_leader.id]).update
 

--- a/spec/services/leader_updater_spec.rb
+++ b/spec/services/leader_updater_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe LeaderUpdater, '#update' do
+  it 'removes leaders whose ids are not passed in' do
+    group = create :group
+    leader = create :user1
+    other_leader = create :user1
+    create :group_member, group: group, userid: leader.id, leader: true
+    create :group_member, group: group, userid: other_leader.id, leader: true
+    notifier = double('notifier')
+    expect(GroupNotifier).to receive(:new)
+      .with(group, 'remove_group_leader', other_leader).and_return(notifier)
+    expect(notifier).to receive(:send_notifications_to)
+      .with([leader, other_leader])
+
+    LeaderUpdater.new(group, [leader.id]).update
+
+    expect(group.leaders).not_to include(other_leader)
+  end
+
+  it 'adds leaders whose ids are passed in' do
+    group = create :group
+    leader = create :user1
+    non_leader = create :user1
+    create :group_member, group: group, userid: leader.id, leader: true
+    create :group_member, group: group, userid: non_leader.id, leader: false
+    notifier = double('notifier')
+    expect(GroupNotifier).to receive(:new)
+      .with(group, 'add_group_leader', non_leader).and_return(notifier)
+    expect(notifier).to receive(:send_notifications_to).with([leader])
+
+    LeaderUpdater.new(group, [leader.id, non_leader.id]).update
+
+    expect(group.leaders).to include(non_leader)
+  end
+end


### PR DESCRIPTION
The ABC of the update_leaders method was too high before this commit.
The method is still pretty long, but the ABC is now below 15.

This version also does one update_all for adding leaders and one for
removing, while the old one looped through each member and updated
individually.