### PR TITLE
 Get jasmine test units working in travis-ci and passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ before_script:
   - /bin/cp $TRAVIS_BUILD_DIR/config/database.example.yml $TRAVIS_BUILD_DIR/config/database.yml 
   - /bin/cp $TRAVIS_BUILD_DIR/config/smtp.example.yml $TRAVIS_BUILD_DIR/config/smtp.yml
   - psql -c 'create database ifme_test;' -U postgres
+script:
+  - bundle exec rake travis
 sudo: false

--- a/spec/javascripts/HeaderSpec.js
+++ b/spec/javascripts/HeaderSpec.js
@@ -150,8 +150,8 @@ describe("Header", function() {
 
     it("has changed expand_nav opacity amount to 0.8", function() {
       showSmallTopNav();
-
-      expect($('#expand_nav').css('opacity')).toBe('0.8');
+      opacity = Math.round($('#expand_nav').css('opacity') * 10) / 10
+      expect(opacity).toBe(0.8);
     });
   });
 
@@ -204,15 +204,15 @@ describe("Header", function() {
     });
 
     it("has changed #me opacity amount to 0.8", function() {
-      showExpandMe();
-
-      expect($('#me').css('opacity')).toBe('0.8');
+      showExpandMe(); 
+      opacity = Math.round($('#me').css('opacity') * 10) / 10
+      expect(opacity).toBe(0.8);
     });
 
     it("has changed #title_expand opacity amount to 0.8", function() {
       showExpandMe();
-
-      expect($('#title_expand').css('opacity')).toBe('0.8');
+      opacity = Math.round($('#title_expand').css('opacity') * 10) / 10
+      expect(opacity).toBe(0.8);
     });
   });
 


### PR DESCRIPTION
Fixes issue #245 

  This will get your jasmine test units going in travis-ci : ) Note: You had everything right in your Rakefile but travis-ci defaults to running 'rake' and not 'rake travis' so just needed to add that to .travis.yml. Three tests in your header spec were not passing though. This was because the css opacity value was a float with 15 digits of precision and not a string. I modified those tests to round to the first decimal place using Math.round and changed the expectation from a string to a float. 

Cheers