### PR TITLE
Redirecting to groups path if nonleader edits group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -33,7 +33,10 @@ class GroupsController < ApplicationController
 
   # GET /groups/1/edit
   def edit
-    @group_members = GroupMember.where(groupid: @group.id).all
+    unless @group.leaders.include?(current_user)
+      flash[:error] = 'You must be a leader of a group in order to edit it'
+      redirect_to_index
+    end
   end
 
   # POST /groups
@@ -96,11 +99,7 @@ class GroupsController < ApplicationController
                          #{group.name}"
       end
     end
-
-    respond_to do |format|
-      format.html { redirect_to groups_path }
-      format.json { head :no_content }
-    end
+    redirect_to_index
   end
 
   # DELETE /groups/1
@@ -108,10 +107,7 @@ class GroupsController < ApplicationController
   def destroy
     @group.destroy
 
-    respond_to do |format|
-      format.html { redirect_to groups_path }
-      format.json { head :no_content }
-    end
+    redirect_to_index
   end
 
   private
@@ -156,6 +152,13 @@ class GroupsController < ApplicationController
     respond_to do |format|
       format.html { redirect_to group_path(@group) }
       format.json { render :show, status: :created, location: @group }
+    end
+  end
+
+  def redirect_to_index
+    respond_to do |format|
+      format.html { redirect_to groups_path }
+      format.json { head :no_content }
     end
   end
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe GroupsController, :type => :controller do
     end
   end
 
+  describe 'GET #edit' do
+    it 'redirects to groups path when current_user is not a leader' do
+      stub_current_user
+      group = create :group
+      get :edit, id: group.id
+
+      expect(response).to redirect_to(groups_path)
+    end
+  end
+
   describe "GET #leave" do
     context "when current_user is the only leader of the group" do
       it "redirects to groups_path with alert message" do

--- a/spec/features/leader_edits_groups_spec.rb
+++ b/spec/features/leader_edits_groups_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.feature "LeaderEditsGroups", type: :feature do
+  scenario 'successfully' do
+    user = create :user
+    login_as user
+    group = create :group_with_member, userid: user.id, leader: true
+    visit edit_group_path(group)
+
+    expect(page).to have_content("Edit #{group.name}")
+  end
+end

--- a/spec/features/user_leaves_groups_spec.rb
+++ b/spec/features/user_leaves_groups_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "UserLeavesGroups", type: :feature do
     click_link "Leave"
 
     expect(page).to have_content("You have left #{group.name}")
+    expect(current_path).to eq(groups_path)
   end
 
   scenario 'user removes other member from group' do
@@ -28,5 +29,6 @@ RSpec.feature "UserLeavesGroups", type: :feature do
     expect(page).to have_content(
       "You have removed #{other_member.name} from #{group.name}"
     )
+    expect(current_path).to eq(groups_path)
   end
 end


### PR DESCRIPTION
Before this commit, anyone could visit the edit group page directly via
URL. Although they are unlikely to do this, we should still redirect if
the authenticated user is not a leader of the group.

Other notes:
* The @group_members variable wasn't being used, I think I had switched
the view to use @group.members earlier and forgot to clean up the
controller action
* I extracted the redirect_to_index helper and added a check on
user_leaves_group feature spec to make sure it works