### PR TITLE
Only run metrics for Ruby and JavaScript

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,8 +12,6 @@ engines:
       languages:
       - ruby
       - javascript
-      - python
-      - php
   eslint:
     enabled: true
   fixme:
@@ -24,17 +22,9 @@ ratings:
   paths:
   - Gemfile.lock
   - "**.erb"
-  - "**.haml"
   - "**.rb"
-  - "**.rhtml"
-  - "**.slim"
   - "**.css"
-  - "**.inc"
   - "**.js"
-  - "**.jsx"
-  - "**.module"
-  - "**.php"
-  - "**.py"
 exclude_paths:
 - config/
 - db/


### PR DESCRIPTION
We don't need to add configuration details for other languages. 