### PR TITLE
ReadMore text fade/expansion on the contributors page

### DIFF
--- a/app/assets/javascripts/contributors_readmore.js
+++ b/app/assets/javascripts/contributors_readmore.js
@@ -1,0 +1,33 @@
+$(function(){
+    var totalChars = 0;
+	var max = 250;
+	var visible, invisible;
+
+    // For each contributor profile's content
+	$('.character-limit').each(function(i){
+		totalChars = $(this).text().length;
+
+        // Creates a read-more button only if the content exceeds 250 chars
+        if (totalChars > max){
+            visible = $(this).text().substr(0, max);
+            invisible = $(this).text().substr(max, totalChars - max);
+
+            var content = visible + '<a href="#" class="read-more-show hide">...</a><span class="read-more-content">' + invisible + '</span>';
+            $(this).html(content);
+
+            // Hides overflow content
+            $('.read-more-content').addClass('hide')
+            $('.read-more-show, .read-more-hide').removeClass('hide')
+        }
+	});
+
+    // On click, reveals overflow content
+    $('.read-more-show').on('click', function(e){
+        $(this).fadeOut(400, function(){
+            $(this).next('.read-more-content').removeClass('hide').slideDown(1000);
+            //$(this).next()slideDown(600);
+            $(this).addClass('hide');
+        });
+        e.preventDefault();
+    });
+});

--- a/app/assets/javascripts/contributors_readmore.js
+++ b/app/assets/javascripts/contributors_readmore.js
@@ -1,25 +1,4 @@
-var contributorReadMoreFeature = (function(){
-    var profileTextLength = 0;
-	const maxProfileLength = 250;
-	var visibleProfileText, invisibleProfileText;
-
-	$('.contributor-profile').each(function(i){
-		profileTextLength = $(this).text().length;
-
-        if (profileTextLength > maxProfileLength){
-            visibleProfileText = $(this).text().substr(0, maxProfileLength);
-            invisibleProfileText = $(this).text().substr(maxProfileLength, profileTextLength - maxProfileLength);
-
-            var profileContent = visibleProfileText + '<a href="#" class="read-more-show hide">...</a><span class="read-more-content">' 
-                + invisibleProfileText + '</span>';
-            
-            $(this).html(profileContent);
-
-            $('.read-more-content').addClass('hide')
-            $('.read-more-show, .read-more-hide').removeClass('hide')
-        }
-	});
-
+var readMoreShow = (function(){
     $('.read-more-show').on('click', function(e){
         $(this).fadeOut(400, function(){
             $(this).next('.read-more-content').removeClass('hide').slideDown(1000);
@@ -29,5 +8,31 @@ var contributorReadMoreFeature = (function(){
     });
 });
 
+var contributorReadMoreFeature = (function(){
+    
+        var profileTextLength = 0;
+    	const maxProfileLength = 250;
+    	var visibleProfileText, invisibleProfileText;
+        var contributorProfle = $('.contributor-profile');
+
+    	contributorProfle.each(function(i){
+    		profileTextLength = $(this).text().length;
+
+            if (profileTextLength > maxProfileLength){
+                visibleProfileText = $(this).text().substr(0, maxProfileLength);
+                invisibleProfileText = $(this).text().substr(maxProfileLength, profileTextLength - maxProfileLength);
+
+                var profileContent = visibleProfileText + '<a href="#" class="read-more-show hide">...</a><span class="read-more-content">' 
+                    + invisibleProfileText + '</span>';
+                
+                $(this).html(profileContent);
+
+                $('.read-more-content').addClass('hide')
+                $('.read-more-show, .read-more-hide').removeClass('hide')
+            }
+    	});
+
+        readMoreShow();        
+});
 
 $(document).on("page:load ready", contributorReadMoreFeature);

--- a/app/assets/javascripts/contributors_readmore.js
+++ b/app/assets/javascripts/contributors_readmore.js
@@ -1,4 +1,9 @@
-var readMoreShow = (function(){
+var readMoreHideContent = function(){
+    $('.read-more-content').addClass('hide');
+    $('.read-more-show, .read-more-hide').removeClass('hide');
+};
+
+var readMoreShowContent = function(){
     $('.read-more-show').on('click', function(e){
         $(this).fadeOut(400, function(){
             $(this).next('.read-more-content').removeClass('hide').slideDown(1000);
@@ -6,10 +11,9 @@ var readMoreShow = (function(){
         });
         e.preventDefault();
     });
-});
+};
 
-var contributorReadMoreFeature = (function(){
-    
+var contributorReadMoreFeature = function(){
         var profileTextLength = 0;
     	const maxProfileLength = 250;
     	var visibleProfileText, invisibleProfileText;
@@ -26,13 +30,11 @@ var contributorReadMoreFeature = (function(){
                     + invisibleProfileText + '</span>';
                 
                 $(this).html(profileContent);
-
-                $('.read-more-content').addClass('hide')
-                $('.read-more-show, .read-more-hide').removeClass('hide')
+                readMoreHideContent();
             }
     	});
 
-        readMoreShow();        
-});
+    readMoreShowContent();        
+};
 
 $(document).on("page:load ready", contributorReadMoreFeature);

--- a/app/assets/javascripts/contributors_readmore.js
+++ b/app/assets/javascripts/contributors_readmore.js
@@ -1,4 +1,4 @@
-$(function(){
+var readmore = (function(){
     var totalChars = 0;
 	var max = 250;
 	var visible, invisible;
@@ -28,3 +28,6 @@ $(function(){
         e.preventDefault();
     });
 });
+
+
+$(document).on("page:load ready", readmore);

--- a/app/assets/javascripts/contributors_readmore.js
+++ b/app/assets/javascripts/contributors_readmore.js
@@ -3,29 +3,26 @@ $(function(){
 	var max = 250;
 	var visible, invisible;
 
-    // For each contributor profile's content
 	$('.character-limit').each(function(i){
 		totalChars = $(this).text().length;
 
-        // Creates a read-more button only if the content exceeds 250 chars
         if (totalChars > max){
             visible = $(this).text().substr(0, max);
             invisible = $(this).text().substr(max, totalChars - max);
 
-            var content = visible + '<a href="#" class="read-more-show hide">...</a><span class="read-more-content">' + invisible + '</span>';
+            var content = visible + '<a href="#" class="read-more-show hide">...</a><span class="read-more-content">' 
+                + invisible + '</span>';
+            
             $(this).html(content);
 
-            // Hides overflow content
             $('.read-more-content').addClass('hide')
             $('.read-more-show, .read-more-hide').removeClass('hide')
         }
 	});
 
-    // On click, reveals overflow content
     $('.read-more-show').on('click', function(e){
         $(this).fadeOut(400, function(){
             $(this).next('.read-more-content').removeClass('hide').slideDown(1000);
-            //$(this).next()slideDown(600);
             $(this).addClass('hide');
         });
         e.preventDefault();

--- a/app/assets/javascripts/contributors_readmore.js
+++ b/app/assets/javascripts/contributors_readmore.js
@@ -1,19 +1,19 @@
-var readmore = (function(){
-    var totalChars = 0;
-	var max = 250;
-	var visible, invisible;
+var contributorReadMoreFeature = (function(){
+    var profileTextLength = 0;
+	const maxProfileLength = 250;
+	var visibleProfileText, invisibleProfileText;
 
-	$('.character-limit').each(function(i){
-		totalChars = $(this).text().length;
+	$('.contributor-profile').each(function(i){
+		profileTextLength = $(this).text().length;
 
-        if (totalChars > max){
-            visible = $(this).text().substr(0, max);
-            invisible = $(this).text().substr(max, totalChars - max);
+        if (profileTextLength > maxProfileLength){
+            visibleProfileText = $(this).text().substr(0, maxProfileLength);
+            invisibleProfileText = $(this).text().substr(maxProfileLength, profileTextLength - maxProfileLength);
 
-            var content = visible + '<a href="#" class="read-more-show hide">...</a><span class="read-more-content">' 
-                + invisible + '</span>';
+            var profileContent = visibleProfileText + '<a href="#" class="read-more-show hide">...</a><span class="read-more-content">' 
+                + invisibleProfileText + '</span>';
             
-            $(this).html(content);
+            $(this).html(profileContent);
 
             $('.read-more-content').addClass('hide')
             $('.read-more-show, .read-more-hide').removeClass('hide')
@@ -30,4 +30,4 @@ var readmore = (function(){
 });
 
 
-$(document).on("page:load ready", readmore);
+$(document).on("page:load ready", contributorReadMoreFeature);

--- a/app/assets/stylesheets/application/contributors.scss
+++ b/app/assets/stylesheets/application/contributors.scss
@@ -51,3 +51,7 @@ div.table div.table_cell {
     text-align: center;
   }
 }
+
+.hide{
+  display: none;
+}

--- a/app/views/pages/contributors.html.erb
+++ b/app/views/pages/contributors.html.erb
@@ -11,7 +11,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Julia Nguyen</div>
 			<div class="spacer"></div>
-			<div class="character-limit">Being open and honest about my journey with obsessive-compulsive disorder, anxiety, and depression helps me to accept myself and reach out for support. My hope is to encourage others to feel more comfortable about sharing their experiences. Growing up as a daughter of Vietnamese refugee parents, it was difficult to talk about mental illness openly. I created if me as a tool to engage loved ones in mental health conversations. Working on the project openly has helped me to further explore my own mental health.</div>
+			<div class="contributor-profile">Being open and honest about my journey with obsessive-compulsive disorder, anxiety, and depression helps me to accept myself and reach out for support. My hope is to encourage others to feel more comfortable about sharing their experiences. Growing up as a daughter of Vietnamese refugee parents, it was difficult to talk about mental illness openly. I created if me as a tool to engage loved ones in mental health conversations. Working on the project openly has helped me to further explore my own mental health.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('julianguyen', 'http://github.com/julianguyen', class: "smaller_margin_right") %>
@@ -25,7 +25,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Jennifer Shen</div>
 			<div class="spacer"></div>
-			<div class="character-limit">I am contributing to if me because one's mental health is often disregarded. It is important that everybody watches and observes how they are feeling on a daily basis, and it is also important that we look out for each other.</div>
+			<div class="contributor-profile">I am contributing to if me because one's mental health is often disregarded. It is important that everybody watches and observes how they are feeling on a daily basis, and it is also important that we look out for each other.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('jzshen', 'http://github.com/jzshen', class: "smaller_margin_right") %>
@@ -39,7 +39,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Jon Tan</div>
 			<div class="spacer"></div>
-			<div class="character-limit">Among the millions of web applications, there are only a handful of web applications catering to individuals with mental heatlh. I am glad that Julia has created if me for the purpose of building this community.</div>
+			<div class="contributor-profile">Among the millions of web applications, there are only a handful of web applications catering to individuals with mental heatlh. I am glad that Julia has created if me for the purpose of building this community.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Mississauga, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('9bits', 'http://github.com/9bits', class: "smaller_margin_right") %>
@@ -53,7 +53,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Jenny Nguyen</div>
 			<div class="spacer"></div>
-			<div class="character-limit">As a health science student I have been exposed medical literature that focuses on neuroplasticity, the idea that our environment and actions can change neural circuitry and pathways, and its role in shaping mental health disorders. For example, studies shows the in people with OCD, there is hyperconnectivity between the orbitofrontal cortex and the caudate nucleus, structures of the brain that are responsible for decision-making and thinking. Thus novel treatment of OCD focuses on targeting these principles and beliefs these obsessions and compulsions are founded on in order to rewire the brain. I believe if me provides a platform to habitually reflect and help manage one’s wellbeing in addition to formal medical treatment.</div>
+			<div class="contributor-profile">As a health science student I have been exposed medical literature that focuses on neuroplasticity, the idea that our environment and actions can change neural circuitry and pathways, and its role in shaping mental health disorders. For example, studies shows the in people with OCD, there is hyperconnectivity between the orbitofrontal cortex and the caudate nucleus, structures of the brain that are responsible for decision-making and thinking. Thus novel treatment of OCD focuses on targeting these principles and beliefs these obsessions and compulsions are founded on in order to rewire the brain. I believe if me provides a platform to habitually reflect and help manage one’s wellbeing in addition to formal medical treatment.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('nguyenjenny', 'http://github.com/nguyenjenny', class: "smaller_margin_right") %>
@@ -67,7 +67,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Srishti Gupta</div>
 			<div class="spacer"></div>
-			<div class="character-limit">if me is important to me because I see the need for it to exist, because it aims to build support networks for its users and help them grow as individuals and externally be truthful to themselves about what they need to do and when they need to do it, as well as be able to reach out and get advice on how to do things better and can choose to be completely anonymous in the process if they so choose to be. And what makes it even more distinctive is its target audience – because with the stigmas surrounding mental health and various other things, it is very difficult for individuals with mental health concerns to find the right kind of support, because only the individual can determine if something is actually benefitting them. if me allows you to build your own support system and change it as you please which I find very unique, and something everyone should at least give a try, regardless of whether or not  you currently have mental health concerns. I enjoy learning and helping make a meaningful impact, and contributing to if me helps me do that.</div>
+			<div class="contributor-profile">if me is important to me because I see the need for it to exist, because it aims to build support networks for its users and help them grow as individuals and externally be truthful to themselves about what they need to do and when they need to do it, as well as be able to reach out and get advice on how to do things better and can choose to be completely anonymous in the process if they so choose to be. And what makes it even more distinctive is its target audience – because with the stigmas surrounding mental health and various other things, it is very difficult for individuals with mental health concerns to find the right kind of support, because only the individual can determine if something is actually benefitting them. if me allows you to build your own support system and change it as you please which I find very unique, and something everyone should at least give a try, regardless of whether or not  you currently have mental health concerns. I enjoy learning and helping make a meaningful impact, and contributing to if me helps me do that.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Mombasa, Kenya
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('srishtig', 'http://github.com/srishtig', class: "smaller_margin_right") %>
@@ -81,7 +81,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Alex Falconer-Athanassakos</div>
 			<div class="spacer"></div>
-			<div class="character-limit">People can struggle with their minds despite everything being “right” in their lives. People’s minds can also give them remarkable resilience through serious adversity. I have been studying for years, in fields from biology to philosophy, to understand this and make a contribution. The internet needs a comprehensive, community-based mental health resource and if me has the kind of people behind it to make it happen.</div>
+			<div class="contributor-profile">People can struggle with their minds despite everything being “right” in their lives. People’s minds can also give them remarkable resilience through serious adversity. I have been studying for years, in fields from biology to philosophy, to understand this and make a contribution. The internet needs a comprehensive, community-based mental health resource and if me has the kind of people behind it to make it happen.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-globe fa-inline fa-left"></i><%= link_to('alexfa.net', 'http://alexfa.net/', class: "smaller_margin_right") %>
@@ -95,7 +95,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Gurpreet Gill</div>
 			<div class="spacer"></div>
-			<div class="character-limit">Being mentally healthy is very important because it not only helps you overcome everyday stress but also makes you more productive and a better contributor. If me allows you to find help and also gives you the opportunity to help others. It ensures that your mental health is in a well-being state by allowing you to share, relate and connect with others. I joined if me because it is a great web application which ensures we all are there for each other.</div>
+			<div class="contributor-profile">Being mentally healthy is very important because it not only helps you overcome everyday stress but also makes you more productive and a better contributor. If me allows you to find help and also gives you the opportunity to help others. It ensures that your mental health is in a well-being state by allowing you to share, relate and connect with others. I joined if me because it is a great web application which ensures we all are there for each other.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Brampton, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('gCrew', 'http://github.com/gcrew', class: "smaller_margin_right") %>
@@ -109,7 +109,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Lucy Yu</div>
 			<div class="spacer"></div>
-			<div class="character-limit">"The mind is its own place, and in itself can make a heaven of hell, a hell of heaven." — John Milton, <i>Paradise Lost</i>
+			<div class="contributor-profile">"The mind is its own place, and in itself can make a heaven of hell, a hell of heaven." — John Milton, <i>Paradise Lost</i>
 			<br>
 			<br>
 			Our minds are the very screens behind which we perceive the world, yet there is not enough discourse on the importance of sanity. <i>if me</i> is the community I wish existed during my dark times, and I'm hoping to help someone through theirs by contributing to this project.</div>
@@ -126,7 +126,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Tara Wilkins</div>
 			<div class="spacer"></div>
-			<div class="character-limit">Tara works at the national workshop company <%= link_to('Camp Tech', 'http://camptech.ca') %>, where she oversees marketing, runs the day-to-day operations and teaches digital marketing. Outside of her work with Camp Tech, she fosters semi-feral cats with the <%= link_to('Annex Cat Rescue', 'http://annexcatrescue.ca') %>, curates creative events for the <%= link_to('Makers Digest', 'http://themakersdigest.com') %> and is excited to now be a part of if me. Having personal experiences with mental health herself, Tara is acutely aware of the impact that mental illness can have on lives, families and the workplace. She strongly believes in the power of sharing to erase the stigma and break through barriers. And most of all, she believes in the power of getting help.</div>
+			<div class="contributor-profile">Tara works at the national workshop company <%= link_to('Camp Tech', 'http://camptech.ca') %>, where she oversees marketing, runs the day-to-day operations and teaches digital marketing. Outside of her work with Camp Tech, she fosters semi-feral cats with the <%= link_to('Annex Cat Rescue', 'http://annexcatrescue.ca') %>, curates creative events for the <%= link_to('Makers Digest', 'http://themakersdigest.com') %> and is excited to now be a part of if me. Having personal experiences with mental health herself, Tara is acutely aware of the impact that mental illness can have on lives, families and the workplace. She strongly believes in the power of sharing to erase the stigma and break through barriers. And most of all, she believes in the power of getting help.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-twitter fa-inline fa-left"></i><%= link_to('TaraEWilkins', 'https://twitter.com/TaraEWilkins', class: "smaller_margin_right") %>
@@ -140,7 +140,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Darryl Dixon</div>
 			<div class="spacer"></div>
-			<div class="character-limit">As the saying goes: "You are your own worst enemy." Your experience regarding this quote may very, but remember: nothing happens without your brain. Mental health is an important topic of discussion, one that far too many people are afraid to be open about, and far too many don't believe that this is a legitimate concern, resulting in few people finding someone to simply vent to, let alone getting help. The goal of if me is to break that habit, to help others with mental illness find help and a to communicate with their loved ones about their issues.</div>
+			<div class="contributor-profile">As the saying goes: "You are your own worst enemy." Your experience regarding this quote may very, but remember: nothing happens without your brain. Mental health is an important topic of discussion, one that far too many people are afraid to be open about, and far too many don't believe that this is a legitimate concern, resulting in few people finding someone to simply vent to, let alone getting help. The goal of if me is to break that habit, to help others with mental illness find help and a to communicate with their loved ones about their issues.</div>
 			<div class="spacer"></div>
 			Darryl Dixon is a rad cat that loves web development, is a generalist full-stack JavaScript developer, and loves to give back to the community in some way, anywhere.
 			<div class="spacer"></div>

--- a/app/views/pages/contributors.html.erb
+++ b/app/views/pages/contributors.html.erb
@@ -1,7 +1,9 @@
-<% title 'Contributors' %>
-<span class="emphasis">if me is built and maintained by volunteers of many different backgrounds and skill sets.</span>
-
-<p class="intro">We're always looking for ideas from everyone, including <strong>mental health advocates</strong>, <strong>health professionals</strong>, <strong>software developers</strong>, and <strong>user experience designers</strong>! Please email <a href="mailto:join.ifme@gmail.com">us</a> and we'll connect with you! You will be invited to participate in our <a href="https://ifme.slack.com" target="_blank">Slack</a> page, our primary communication tool. Be sure to fork our repository hosted on <a href="https://github.com/julianguyen/ifme" target="_blank">GitHub</a>!</p>
+<% title t('pages.contributors.title') %>
+<%= raw t('pages.contributors.description', {
+	email_link: link_to(t('us'), "mailto:#{t('email')}"),
+	slack_link: link_to(t('slack'), 'https://ifme.slack.com', target: 'blank'),
+	github_link: link_to(t('github'), 'https://github.com/julianguyen/ifme', target: 'blank')
+	}) %>
 
 <div class="contributors table">
 	<div class="contributor table_row">
@@ -151,11 +153,11 @@
 </div>
 
 <div class="spacer"></div>
-<div class="contributor-name">More Fabulous Contributors!</div>
+<div class="contributor-name"><%= t('pages.contributors.more_contributors') %></div>
 <div class="spacer"></div>
-A huge thanks to <%= print_contributors(@contributors) %>
+<%= t('pages.contributors.thanks') %> <%= print_contributors(@contributors) %>
 
 <div class="spacer"></div>
-<div class="contributor-name">Organizations We've Partnered With!</div>
+<div class="contributor-name"><%= t('pages.contributors.partners') %></div>
 <div class="spacer"></div>
 <%= print_partners(@organizations) %>

--- a/app/views/pages/contributors.html.erb
+++ b/app/views/pages/contributors.html.erb
@@ -1,7 +1,7 @@
 <% title 'Contributors' %>
 <span class="emphasis">if me is built and maintained by volunteers of many different backgrounds and skill sets.</span>
 
-<p>We're always looking for ideas from everyone, including <strong>mental health advocates</strong>, <strong>health professionals</strong>, <strong>software developers</strong>, and <strong>user experience designers</strong>! Please email <a href="mailto:join.ifme@gmail.com">us</a> and we'll connect with you! You will be invited to participate in our <a href="https://ifme.slack.com" target="_blank">Slack</a> page, our primary communication tool. Be sure to fork our repository hosted on <a href="https://github.com/julianguyen/ifme" target="_blank">GitHub</a>!</p>
+<p class="intro">We're always looking for ideas from everyone, including <strong>mental health advocates</strong>, <strong>health professionals</strong>, <strong>software developers</strong>, and <strong>user experience designers</strong>! Please email <a href="mailto:join.ifme@gmail.com">us</a> and we'll connect with you! You will be invited to participate in our <a href="https://ifme.slack.com" target="_blank">Slack</a> page, our primary communication tool. Be sure to fork our repository hosted on <a href="https://github.com/julianguyen/ifme" target="_blank">GitHub</a>!</p>
 
 <div class="contributors table">
 	<div class="contributor table_row">
@@ -11,7 +11,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Julia Nguyen</div>
 			<div class="spacer"></div>
-			Being open and honest about my journey with obsessive-compulsive disorder, anxiety, and depression helps me to accept myself and reach out for support. My hope is to encourage others to feel more comfortable about sharing their experiences. Growing up as a daughter of Vietnamese refugee parents, it was difficult to talk about mental illness openly. I created if me as a tool to engage loved ones in mental health conversations. Working on the project openly has helped me to further explore my own mental health.
+			<div class="character-limit">Being open and honest about my journey with obsessive-compulsive disorder, anxiety, and depression helps me to accept myself and reach out for support. My hope is to encourage others to feel more comfortable about sharing their experiences. Growing up as a daughter of Vietnamese refugee parents, it was difficult to talk about mental illness openly. I created if me as a tool to engage loved ones in mental health conversations. Working on the project openly has helped me to further explore my own mental health.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('julianguyen', 'http://github.com/julianguyen', class: "smaller_margin_right") %>
@@ -25,7 +25,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Jennifer Shen</div>
 			<div class="spacer"></div>
-			I am contributing to if me because one's mental health is often disregarded. It is important that everybody watches and observes how they are feeling on a daily basis, and it is also important that we look out for each other.
+			<div class="character-limit">I am contributing to if me because one's mental health is often disregarded. It is important that everybody watches and observes how they are feeling on a daily basis, and it is also important that we look out for each other.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('jzshen', 'http://github.com/jzshen', class: "smaller_margin_right") %>
@@ -39,7 +39,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Jon Tan</div>
 			<div class="spacer"></div>
-			Among the millions of web applications, there are only a handful of web applications catering to individuals with mental heatlh. I am glad that Julia has created if me for the purpose of building this community.
+			<div class="character-limit">Among the millions of web applications, there are only a handful of web applications catering to individuals with mental heatlh. I am glad that Julia has created if me for the purpose of building this community.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Mississauga, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('9bits', 'http://github.com/9bits', class: "smaller_margin_right") %>
@@ -53,7 +53,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Jenny Nguyen</div>
 			<div class="spacer"></div>
-			As a health science student I have been exposed medical literature that focuses on neuroplasticity, the idea that our environment and actions can change neural circuitry and pathways, and its role in shaping mental health disorders. For example, studies shows the in people with OCD, there is hyperconnectivity between the orbitofrontal cortex and the caudate nucleus, structures of the brain that are responsible for decision-making and thinking. Thus novel treatment of OCD focuses on targeting these principles and beliefs these obsessions and compulsions are founded on in order to rewire the brain. I believe if me provides a platform to habitually reflect and help manage one’s wellbeing in addition to formal medical treatment.
+			<div class="character-limit">As a health science student I have been exposed medical literature that focuses on neuroplasticity, the idea that our environment and actions can change neural circuitry and pathways, and its role in shaping mental health disorders. For example, studies shows the in people with OCD, there is hyperconnectivity between the orbitofrontal cortex and the caudate nucleus, structures of the brain that are responsible for decision-making and thinking. Thus novel treatment of OCD focuses on targeting these principles and beliefs these obsessions and compulsions are founded on in order to rewire the brain. I believe if me provides a platform to habitually reflect and help manage one’s wellbeing in addition to formal medical treatment.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('nguyenjenny', 'http://github.com/nguyenjenny', class: "smaller_margin_right") %>
@@ -67,7 +67,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Srishti Gupta</div>
 			<div class="spacer"></div>
-			if me is important to me because I see the need for it to exist, because it aims to build support networks for its users and help them grow as individuals and externally be truthful to themselves about what they need to do and when they need to do it, as well as be able to reach out and get advice on how to do things better and can choose to be completely anonymous in the process if they so choose to be. And what makes it even more distinctive is its target audience – because with the stigmas surrounding mental health and various other things, it is very difficult for individuals with mental health concerns to find the right kind of support, because only the individual can determine if something is actually benefitting them. if me allows you to build your own support system and change it as you please which I find very unique, and something everyone should at least give a try, regardless of whether or not  you currently have mental health concerns. I enjoy learning and helping make a meaningful impact, and contributing to if me helps me do that.
+			<div class="character-limit">if me is important to me because I see the need for it to exist, because it aims to build support networks for its users and help them grow as individuals and externally be truthful to themselves about what they need to do and when they need to do it, as well as be able to reach out and get advice on how to do things better and can choose to be completely anonymous in the process if they so choose to be. And what makes it even more distinctive is its target audience – because with the stigmas surrounding mental health and various other things, it is very difficult for individuals with mental health concerns to find the right kind of support, because only the individual can determine if something is actually benefitting them. if me allows you to build your own support system and change it as you please which I find very unique, and something everyone should at least give a try, regardless of whether or not  you currently have mental health concerns. I enjoy learning and helping make a meaningful impact, and contributing to if me helps me do that.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Mombasa, Kenya
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('srishtig', 'http://github.com/srishtig', class: "smaller_margin_right") %>
@@ -81,7 +81,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Alex Falconer-Athanassakos</div>
 			<div class="spacer"></div>
-			People can struggle with their minds despite everything being “right” in their lives. People’s minds can also give them remarkable resilience through serious adversity. I have been studying for years, in fields from biology to philosophy, to understand this and make a contribution. The internet needs a comprehensive, community-based mental health resource and if me has the kind of people behind it to make it happen.
+			<div class="character-limit">People can struggle with their minds despite everything being “right” in their lives. People’s minds can also give them remarkable resilience through serious adversity. I have been studying for years, in fields from biology to philosophy, to understand this and make a contribution. The internet needs a comprehensive, community-based mental health resource and if me has the kind of people behind it to make it happen.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-globe fa-inline fa-left"></i><%= link_to('alexfa.net', 'http://alexfa.net/', class: "smaller_margin_right") %>
@@ -95,7 +95,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Gurpreet Gill</div>
 			<div class="spacer"></div>
-			Being mentally healthy is very important because it not only helps you overcome everyday stress but also makes you more productive and a better contributor. If me allows you to find help and also gives you the opportunity to help others. It ensures that your mental health is in a well-being state by allowing you to share, relate and connect with others. I joined if me because it is a great web application which ensures we all are there for each other.
+			<div class="character-limit">Being mentally healthy is very important because it not only helps you overcome everyday stress but also makes you more productive and a better contributor. If me allows you to find help and also gives you the opportunity to help others. It ensures that your mental health is in a well-being state by allowing you to share, relate and connect with others. I joined if me because it is a great web application which ensures we all are there for each other.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Brampton, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('gCrew', 'http://github.com/gcrew', class: "smaller_margin_right") %>
@@ -109,10 +109,10 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Lucy Yu</div>
 			<div class="spacer"></div>
-			"The mind is its own place, and in itself can make a heaven of hell, a hell of heaven." — John Milton, <i>Paradise Lost</i>
+			<div class="character-limit">"The mind is its own place, and in itself can make a heaven of hell, a hell of heaven." — John Milton, <i>Paradise Lost</i>
 			<br>
 			<br>
-			Our minds are the very screens behind which we perceive the world, yet there is not enough discourse on the importance of sanity. <i>if me</i> is the community I wish existed during my dark times, and I'm hoping to help someone through theirs by contributing to this project.
+			Our minds are the very screens behind which we perceive the world, yet there is not enough discourse on the importance of sanity. <i>if me</i> is the community I wish existed during my dark times, and I'm hoping to help someone through theirs by contributing to this project.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Mississauga, Canada
 			<i class="fa fa-github fa-inline fa-left"></i><%= link_to('lucyyu24', 'https://github.com/lucyyu24', class: "smaller_margin_right") %>
@@ -126,7 +126,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Tara Wilkins</div>
 			<div class="spacer"></div>
-			Tara works at the national workshop company <%= link_to('Camp Tech', 'http://camptech.ca') %>, where she oversees marketing, runs the day-to-day operations and teaches digital marketing. Outside of her work with Camp Tech, she fosters semi-feral cats with the <%= link_to('Annex Cat Rescue', 'http://annexcatrescue.ca') %>, curates creative events for the <%= link_to('Makers Digest', 'http://themakersdigest.com') %> and is excited to now be a part of if me. Having personal experiences with mental health herself, Tara is acutely aware of the impact that mental illness can have on lives, families and the workplace. She strongly believes in the power of sharing to erase the stigma and break through barriers. And most of all, she believes in the power of getting help.
+			<div class="character-limit">Tara works at the national workshop company <%= link_to('Camp Tech', 'http://camptech.ca') %>, where she oversees marketing, runs the day-to-day operations and teaches digital marketing. Outside of her work with Camp Tech, she fosters semi-feral cats with the <%= link_to('Annex Cat Rescue', 'http://annexcatrescue.ca') %>, curates creative events for the <%= link_to('Makers Digest', 'http://themakersdigest.com') %> and is excited to now be a part of if me. Having personal experiences with mental health herself, Tara is acutely aware of the impact that mental illness can have on lives, families and the workplace. She strongly believes in the power of sharing to erase the stigma and break through barriers. And most of all, she believes in the power of getting help.</div>
 			<div class="spacer"></div>
 			<i class="fa fa-location-arrow fa-inline"></i> Toronto, Canada
 			<i class="fa fa-twitter fa-inline fa-left"></i><%= link_to('TaraEWilkins', 'https://twitter.com/TaraEWilkins', class: "smaller_margin_right") %>
@@ -140,7 +140,7 @@
 		<div class="about-contributor table_cell">
 			<div class="contributor-name">Darryl Dixon</div>
 			<div class="spacer"></div>
-			As the saying goes: "You are your own worst enemy." Your experience regarding this quote may very, but remember: nothing happens without your brain. Mental health is an important topic of discussion, one that far too many people are afraid to be open about, and far too many don't believe that this is a legitimate concern, resulting in few people finding someone to simply vent to, let alone getting help. The goal of if me is to break that habit, to help others with mental illness find help and a to communicate with their loved ones about their issues.
+			<div class="character-limit">As the saying goes: "You are your own worst enemy." Your experience regarding this quote may very, but remember: nothing happens without your brain. Mental health is an important topic of discussion, one that far too many people are afraid to be open about, and far too many don't believe that this is a legitimate concern, resulting in few people finding someone to simply vent to, let alone getting help. The goal of if me is to break that habit, to help others with mental illness find help and a to communicate with their loved ones about their issues.</div>
 			<div class="spacer"></div>
 			Darryl Dixon is a rad cat that loves web development, is a generalist full-stack JavaScript developer, and loves to give back to the community in some way, anywhere.
 			<div class="spacer"></div>

--- a/spec/javascripts/ContributorsReadMoreSpec.js
+++ b/spec/javascripts/ContributorsReadMoreSpec.js
@@ -1,0 +1,17 @@
+describe("ContributorsReadMore", function() {
+	var checkFeature;
+  	it("has called contributorReadMoreFeature", function() {
+    	checkFeature = spyOn(window, 'contributorReadMoreFeature');
+    	contributorReadMoreFeature();
+    	expect(checkFeature).toHaveBeenCalled();
+  	});
+
+	it("has called readMoreShow", function() {
+    	checkFeature = spyOn(window, 'readMoreShow');
+    	contributorReadMoreFeature();
+    	expect(checkFeature).toHaveBeenCalled();
+  	});
+
+});
+
+

--- a/spec/javascripts/ContributorsReadMoreSpec.js
+++ b/spec/javascripts/ContributorsReadMoreSpec.js
@@ -6,12 +6,17 @@ describe("ContributorsReadMore", function() {
     	expect(checkFeature).toHaveBeenCalled();
   	});
 
-	it("has called readMoreShow", function() {
-    	checkFeature = spyOn(window, 'readMoreShow');
+	it("has called readMoreShowContent", function() {
+    	checkFeature = spyOn(window, 'readMoreShowContent');
     	contributorReadMoreFeature();
     	expect(checkFeature).toHaveBeenCalled();
   	});
 
+	it("has called readMoreHideContent", function(){
+  		checkFeature = spyOn(window, 'readMoreHideContent');
+  		readMoreHideContent();
+  		expect(checkFeature).toHaveBeenCalled();
+  	});
 });
 
 


### PR DESCRIPTION
This adds a very simple text expansion on contributor profiles with a character count > 250. I am just starting off with Javascript and know a little HTML/CSS, so I'd love to get some feedback on this. I'm thinking of removing the '...' and adding a visual text-fade, since this appears a bit clunky. 

![screen shot 2016-08-15 at 6 36 37 pm](https://cloud.githubusercontent.com/assets/16668970/17720240/670527a0-63ee-11e6-8c93-00763eef60b3.png)
![screen shot 2016-08-15 at 6 36 50 pm](https://cloud.githubusercontent.com/assets/16668970/17720241/670528b8-63ee-11e6-927c-c08f2242ff27.png)

I also noticed that while running the app locally, if I click onto the contributors' link at the bottom, the page shows up without the feature I'm adding. It only shows up after refreshing once I'm on the contributors page. Not sure why that is happening.