### PR TITLE
Siena/fully qualify i18n

### DIFF
--- a/app/views/allies/index.html.erb
+++ b/app/views/allies/index.html.erb
@@ -10,7 +10,7 @@
 <div class="spacer"></div>
 
 <% if !@outgoing_ally_requests.empty? %>
-  <strong><%= t('.outgoing') %></strong>
+  <strong><%= t('allies.index.outgoing') %></strong>
   <br>
   <br>
   <% @outgoing_ally_requests.each_with_index do |ally, index| %>
@@ -26,7 +26,7 @@
           <%= ally.location %>
         </div>
         <div class="clear"></div>
-        <%= link_to 'Cancel', remove_allies_path(ally_id: ally.id), :method => :post, data: { confirm: t('.confirm') } %>
+        <%= link_to 'Cancel', remove_allies_path(ally_id: ally.id), :method => :post, data: { confirm: t('allies.index.confirm') } %>
       </div>
   <% end %>
 <% end %>
@@ -35,7 +35,7 @@
   <% if !@outgoing_ally_requests.empty? %>
     <div class="spacer"></div>
   <% end %>
-  <strong><%= t('.incoming') %></strong>
+  <strong><%= t('allies.index.incoming') %></strong>
   <br>
   <br>
   <% @incoming_ally_requests.each_with_index do |ally, index| %>
@@ -51,7 +51,7 @@
           <%= ally.location %>
         </div>
         <div class="clear"></div>
-        <%= link_to 'Accept', add_allies_path(ally_id: ally.id), method: :post %> | <%= link_to 'Reject', remove_allies_path(ally_id: ally.id), :method => :post, data: { confirm: t('.confirm') } %>
+        <%= link_to 'Accept', add_allies_path(ally_id: ally.id), method: :post %> | <%= link_to 'Reject', remove_allies_path(ally_id: ally.id), :method => :post, data: { confirm: t('allies.index.confirm') } %>
       </div>
   <% end %>
 <% end %>
@@ -77,12 +77,12 @@
             <%= ally.location %>
           </div>
           <div class="clear"></div>
-            <%= link_to 'Remove', remove_allies_path(ally_id: ally.id), :method => :post, data: { confirm: t('.confirm') } %>
+            <%= link_to 'Remove', remove_allies_path(ally_id: ally.id), :method => :post, data: { confirm: t('allies.index.confirm') } %>
         </div>
       </div>
     </div>
 <% end %>
 
 <% if @outgoing_ally_requests.empty? && @incoming_ally_requests.empty? && @accepted_allies.count == 0 %>
-  <%= t('.none') %>
+  <%= t('allies.index.none') %>
 <% end %>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -2,13 +2,13 @@
 
 <% if @category.errors.any? %>
   <div class="error_explanation">
-    <%= t('.error_explanation') %>
+    <%= t('categories.form.error_explanation') %>
   </div>
 <% end %>
 
   <div class="field">
     <div class="label">
-      <%= f.label t('.name'), for: 'category_name' %>
+      <%= f.label t('categories.form.name'), for: 'category_name' %>
       <div class="align_right">
         <span class="yes_title" title="Categorize recurring people, places, things, activities, and more"><i class="fa fa-question-circle"></i></span>
         <i class="fa fa-exclamation-circle"></i>
@@ -20,7 +20,7 @@
 
   <div class="field">
     <div class="label">
-      <%= f.label t('.description'), for: 'category_description' %>
+      <%= f.label t('categories.form.description'), for: 'category_description' %>
     </div>
     <%= f.cktext_area :description, class: 'no_title special_textarea ckeditor' %>
   </div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,7 +1,7 @@
 <% title 'Categories' %>
 <% page_new new_category_path %>
 <div class="subtitle">
-  <%= t('.subtitle') %>
+  <%= t('categories.index.subtitle') %>
 </div>
 
 <div class="spacer"></div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,10 +1,10 @@
 <% title 'Error' %>
 <div class="pageerror">
   <div class="main_message">
-  	<%= t('.header_message') %>
+  	<%= t('errors.internal_server_error.header_message') %>
   </div>
 
   <div class="message_text">
-  	<%= link_to t('.home_page'), root_url %>
+  	<%= link_to t('errors.internal_server_error.home_page'), root_url %>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,10 +1,10 @@
 <% title 'Error' %>
 <div class="pageerror">
   <div class="main_message">
-  	<%= t('.header_message') %>
+  	<%= t('errors.not_found.header_message') %>
   </div>
 
   <div class="message_text">
-  	<%= link_to t('.home_page'), root_url %>
+  	<%= link_to t('errors.not_found.home_page'), root_url %>
   </div>
 </div>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -13,7 +13,7 @@
 <% if action_name == "new" || action_name == "create" %>
   <div class="field">
     <div class="label">
-      <%= f.label t('.name'), for: 'group_name' %>
+      <%= f.label t('groups.form.name'), for: 'group_name' %>
       <i class="fa fa-exclamation-circle align_right"></i>
       <div class="clear"></div>
     </div>
@@ -22,7 +22,7 @@
 
   <div class="field">
     <div class="label">
-      <%= f.label t('.description'), for: 'group_description' %>
+      <%= f.label t('groups.form.description'), for: 'group_description' %>
       <i class="fa fa-exclamation-circle align_right"></i>
       <div class="clear"></div>
     </div>
@@ -34,7 +34,7 @@
 
   <div class="table_cell vertical_align_top padding_right">
     <div class="sidebar_field">
-      <div class="sidebar_label"><%= f.label t('.name') %></div>
+      <div class="sidebar_label"><%= f.label t('groups.form.name') %></div>
       <%= f.text_field :name, :class => "name_field" %>
     </div>
 
@@ -42,7 +42,7 @@
 
       <% if @group.group_members.count > 1 %>
         <div class="sidebar_label">
-          <%= f.label t('.leaders') %>
+          <%= f.label t('groups.form.leaders') %>
         </div>
 
         <% @group.group_members.each do |member| %>
@@ -52,7 +52,7 @@
         <% end %>
       <% else %>
         <div class="small_font subtle">
-          <%= t('.only_leader') %>
+          <%= t('groups.form.only_leader') %>
         </div>
       <% end %>
       </div>
@@ -62,7 +62,7 @@
 
     <div class="field">
       <div class="label">
-        <%= f.label t('.description') %>
+        <%= f.label t('groups.form.description') %>
       </div>
 
       <%= f.cktext_area :description, class: 'no_title special_textarea ckeditor' %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -2,7 +2,7 @@
 <% page_new new_group_path %>
 
 <div class="subtitle">
-  <%= t('.subtitle') %>
+  <%= t('groups.index.subtitle') %>
 </div>
 
 <div class="spacer"></div>
@@ -13,7 +13,7 @@
     <div class="group <%= 'no_margin_bottom' if group == @groups.last %>">
       <h1 class="group_name">
         <%= link_to group.name, group %>
-        (<%= t('.leader') if user_is_leader_of? group %>)
+        (<%= t('groups.index.leader') if user_is_leader_of? group %>)
       </h1>
 
       <div class="notification_wrapper small_margin_bottom">

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -17,7 +17,7 @@
 
   <strong>
     <i class="fa fa-key small_margin_right"></i>
-    <%= t('.led_by') %>
+    <%= t('groups.show.led_by') %>
   </strong>
 
   <% @group.leaders.each do |leader| %>

--- a/app/views/layouts/_title.html.erb
+++ b/app/views/layouts/_title.html.erb
@@ -1,4 +1,4 @@
-<%= t(:app_name) %>
+<%= t('app_name') %>
 <% if current_page?(new_user_session_path) ||
     (params[:controller] == "devise/sessions" && action_name == "new") %>
   - Sign in
@@ -12,7 +12,7 @@
     (params[:controller] == "registrations" && action_name == "update") %>
   - Account
 <% elsif current_page?(root_path) %>
-  - <%= t(:app_description) %>
+  - <%= t('app_description') %>
 <% elsif current_page?(new_user_invitation_path) ||
   (params[:controller] == "devise/invitations" && action_name == "new") ||
   (params[:controller] == "users/invitations" && action_name == "create") %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,19 +74,19 @@
             <div id="page_title_content">
               <% if current_page?(new_user_session_path) ||
                   (params[:controller] == "devise/sessions" && action_name == "new") %>
-                <%= t('.signin') %>
+                <%= t('layouts.application.signin') %>
 
               <% elsif current_page?(new_user_registration_path) ||
                 (params[:controller] == "devise/registrations" && action_name == "create") %>
-              <%= t('.create_account') %>
+              <%= t('layouts.application.create_account') %>
 
             <% elsif current_page?(new_user_password_path) ||
               (params[:controller] == "devise/passwords" && action_name == "new") %>
-            <%= t('.forgot_password') %>
+            <%= t('layouts.application.forgot_password') %>
 
           <% elsif current_page?(edit_user_registration_path) ||
             (params[:controller] == "registrations" && action_name == "update") %>
-          <%= t('.update_account') %>
+          <%= t('layouts.application.update_account') %>
 
         <% elsif !@page_edit.blank? %>
           <div class="align_left">
@@ -119,8 +119,8 @@
         <% elsif current_page?(root_path) && !user_signed_in? %>
           <div class="headline center">
             <span class="branding_title">
-              <%= t('.if') %> <span class="branding_subtitle"><%= t('.me') %></span>
-            </span><%= t(:app_description) %>
+              <%= t('layouts.application.if') %> <span class="branding_subtitle"><%= t('layouts.application.me') %></span>
+            </span><%= t('app_description') %>
         </div>
       <% elsif current_page?(new_user_invitation_path) ||
         (params[:controller] == "devise/invitations" && action_name == "new") ||

--- a/app/views/medications/_form.html.erb
+++ b/app/views/medications/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(@medication) do |f| %>
 <% if @medication.errors.any? %>
   <div class="error_explanation">
-    <%= t('.error_explanation') %>
+    <%= t('medications.form.error_explanation') %>
   </div>
 <% end %>
 
@@ -11,7 +11,7 @@
 
     <div class="field" >
       <div class="label">
-        <%= f.label t('.name'), for: 'medication_name' %>
+        <%= f.label t('medications.form.name'), for: 'medication_name' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>
@@ -20,7 +20,7 @@
 
     <div class="field">
       <div class="label">
-        <%= f.label t('.comments') %>
+        <%= f.label t('medications.form.comments') %>
         <div class="align_right">
           <span class="yes_title" title="Additional comments, log your symptoms here"><i class="fa fa-question-circle"></i></span>
         </div>
@@ -35,7 +35,7 @@
 
     <div class="field">
       <div class="label">
-        <%= f.label t('.strength'), for: 'medication_strength' %>
+        <%= f.label t('medications.form.strength'), for: 'medication_strength' %>
         <div class="align_right">
           <span class="yes_title" title="Medication strength, usually found beside the name"><i class="fa fa-question-circle"></i></span>
           <i class="fa fa-exclamation-circle"></i>
@@ -43,7 +43,7 @@
         <div class="clear"></div>
       </div>
       <div class="inline-block">
-        <%= f.number_field :strength, :placeholder => t('.strength_placeholder') %>
+        <%= f.number_field :strength, :placeholder => t('medications.form.strength_placeholder') %>
         <%= f.select(:strength_unit, [['mg', 'mg'], ['ml', 'ml']]) %>
       </div>
     </div>
@@ -58,8 +58,8 @@
         <div class="clear"></div>
       </div>
       <div class="inline-block">
-        <%= f.number_field :total, :placeholder => t('.total_placeholder') %>
-        <%= f.select(:total_unit, [[t('.tablets'), 'tablets'], ['mg', 'mg'], ['ml', 'ml']]) %>
+        <%= f.number_field :total, :placeholder => t('medications.form.total_placeholder') %>
+        <%= f.select(:total_unit, [[t('medications.form.tablets'), 'tablets'], ['mg', 'mg'], ['ml', 'ml']]) %>
       </div>
     </div>
 
@@ -69,7 +69,7 @@
 
     <div class="field">
       <div class="label">
-        <%= f.label t('.dosage'), for: 'medication_dosage' %>
+        <%= f.label t('medications.form.dosage'), for: 'medication_dosage' %>
         <div class="align_right">
           <span class="yes_title" title="Number of pills or servings daily"><i class="fa fa-question-circle"></i></span>
           <i class="fa fa-exclamation-circle"></i>
@@ -77,14 +77,14 @@
         <div class="clear"></div>
       </div>
       <div class="inline-block">
-        <%= f.number_field :dosage, :placeholder => t('.dosage_placeholder') %>
-        <%= f.select(:dosage_unit, [[t('.tablets'), 'tablets'], ['mg', 'mg'], ['ml', 'ml']]) %>
+        <%= f.number_field :dosage, :placeholder => t('medications.form.dosage_placeholder') %>
+        <%= f.select(:dosage_unit, [[t('medications.form.tablets'), 'tablets'], ['mg', 'mg'], ['ml', 'ml']]) %>
       </div>
     </div>
 
     <div class="field">
       <div class="label">
-        <%= f.label t('.refill'), for: 'medication_refill' %>
+        <%= f.label t('medications.form.refill'), for: 'medication_refill' %>
         <div class="align_right">
           <span class="yes_title" title="When to refill this prescription"><i class="fa fa-question-circle"></i></span>
           <i class="fa fa-exclamation-circle"></i>
@@ -99,7 +99,7 @@
         <div class="label no_margin_bottom">
           <div class="inline-block">
             <%= reminder.check_box(:active, { id: 'refill_reminder', class: 'no_margin_left' }, 'true', 'false') %>
-            <%= reminder.label t('.refill_reminder'), for: 'refill_reminder' %>
+            <%= reminder.label t('medications.form.refill_reminder'), for: 'refill_reminder' %>
           </div>
           <div class="align_right">
             <span class="yes_title" title="We'll email you a reminder the week before your medication needs to be refilled"><i class="fa fa-question-circle"></i></span>
@@ -114,7 +114,7 @@
         <div class="label no_margin_bottom">
           <div class="inline-block">
             <%= reminder.check_box(:active, { id: 'take_medication_reminder', class: 'no_margin_left' }, 'true', 'false') %>
-            <%= reminder.label t('.daily_reminder'), for: 'take_medication_reminder' %>
+            <%= reminder.label t('medications.form.daily_reminder'), for: 'take_medication_reminder' %>
           </div>
           <div class="align_right">
             <span class="yes_title" title="We'll email you a daily reminder to take this medication"><i class="fa fa-question-circle"></i></span>

--- a/app/views/medications/index.html.erb
+++ b/app/views/medications/index.html.erb
@@ -2,7 +2,7 @@
 <% page_new new_medication_path %>
 
 <div class="subtitle">
-  <%= t('.subtitle') %>
+  <%= t('medications.index.subtitle') %>
 </div>
 
 <div class="spacer"></div>
@@ -27,9 +27,9 @@ You haven't saved any medications yet. Click <i class="fa fa-plus-circle"></i> t
 <div class="medication no_margin_bottom">
   <h1 class="medication_name">Prozac</h1>
 
-  <strong><%= t('.strength') %></strong> 10 mg
-  <br><strong><%= t('.total') %></strong> 2 tablets
-  <br><strong><%= t('.dosage') %></strong> 40 tablets
-  <br><strong><%= t('.refill') %></strong> 05/31/2016
+  <strong><%= t('medications.index.strength') %></strong> 10 mg
+  <br><strong><%= t('medications.index.total') %></strong> 2 tablets
+  <br><strong><%= t('medications.index.dosage') %></strong> 40 tablets
+  <br><strong><%= t('medications.index.refill') %></strong> 05/31/2016
 </div>
 <% end %>

--- a/app/views/medications/show.html.erb
+++ b/app/views/medications/show.html.erb
@@ -1,19 +1,19 @@
 <% title @medication.name %>
-<strong><%= t('.strength') %></strong>
+<strong><%= t('medications.show.strength') %></strong>
 <%= @medication.strength.to_s + " " + @medication.strength_unit %>
 
-<br><strong><%= t('.quantity') %></strong>
+<br><strong><%= t('medications.show.quantity') %></strong>
 <%= @medication.total.to_s + " " + @medication.total_unit %>
 
-<br><strong><%= t('.dosage') %></strong>
+<br><strong><%= t('medications.show.dosage') %></strong>
 <%= @medication.dosage.to_s + " " + @medication.dosage_unit %>
 
-<br><strong><%= t('.refill') %></strong>
+<br><strong><%= t('medications.show.refill') %></strong>
 <%= @medication.refill %>
 
 <% if !@medication.comments.blank? %>
   <div class="spacer"></div>
-	<strong><%= t('.comments') %></strong>
+	<strong><%= t('medications.show.comments') %></strong>
 	<%= @medication.comments %>
 <% end %>
 

--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(@meeting) do |f| %>
   <% if @meeting.errors.any? %>
     <div class="error_explanation">
-      <%= t('.error_explanation') %>
+      <%= t('meetings.form.error_explanation') %>
     </div>
   <% end %>
 
@@ -11,7 +11,7 @@
 
     <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.name'), for: 'meeting_name' %>
+        <%= f.label t('meetings.form.name'), for: 'meeting_name' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>
@@ -20,16 +20,16 @@
 
     <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.location'), for: 'meeting_location' %>
+        <%= f.label t('meetings.form.location'), for: 'meeting_location' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>
-      <%= f.text_field :location, placeholder: t('.location_placeholder'), class: 'full_field' %>
+      <%= f.text_field :location, placeholder: t('meetings.form.location_placeholder'), class: 'full_field' %>
     </div>
 
     <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.meeting_time'), for: 'meeting_time' %>
+        <%= f.label t('meetings.form.meeting_time'), for: 'meeting_time' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>
@@ -38,7 +38,7 @@
 
     <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.date'), for: 'meeting_date' %>
+        <%= f.label t('meetings.form.date'), for: 'meeting_date' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>
@@ -47,11 +47,11 @@
 
     <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.maximum_members'), for: 'meeting_maxmembers' %>
+        <%= f.label t('meetings.form.maximum_members'), for: 'meeting_maxmembers' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>
-      <%= f.number_field :maxmembers, min: 0, placeholder: t('.maximum_placeholder'), class: 'full_field' %>
+      <%= f.number_field :maxmembers, min: 0, placeholder: t('meetings.form.maximum_placeholder'), class: 'full_field' %>
     </div>
 
   </div>
@@ -60,7 +60,7 @@
 
     <div class="field">
       <div class="label">
-        <%= f.label t('.description'), for: 'meeting_description' %>
+        <%= f.label t('meetings.form.description'), for: 'meeting_description' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>

--- a/app/views/moments/_form.html.erb
+++ b/app/views/moments/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(@moment) do |f| %>
 <% if @moment.errors.any? %>
   <div class="error_explanation">
-    <%= t('.error_explanation') %>
+    <%= t('moments.form.error_explanation') %>
   </div>
 <% end %>
 
@@ -11,7 +11,7 @@
 
     <div class="sidebar_field" >
       <div class="sidebar_label">
-        <%= f.label t('.name'), for: 'moment_name' %>
+        <%= f.label t('moments.form.name'), for: 'moment_name' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>
@@ -26,7 +26,7 @@
         <a href="#" class="toggle_button display_none" id="hideCategories">
           <i class="fa fa-caret-up" ></i>
         </a></i>
-        <%= f.label t('.categories') %>
+        <%= f.label t('moments.form.categories') %>
       </div>
       <div id="categories" class="display_none">
         <div id="categories_list">
@@ -52,7 +52,7 @@
         <a href="#" class="toggle_button display_none" id="hideMoods">
           <i class="fa fa-caret-up" ></i>
         </a>
-        <%= f.label t('.moods') %>
+        <%= f.label t('moments.form.moods') %>
       </div>
 
       <div id="moods" class="display_none">
@@ -79,7 +79,7 @@
         <a href="#" class="toggle_button display_none" id="hideStrategies">
           <i class="fa fa-caret-up" ></i>
         </a>
-        <%= f.label t('.strategies') %>
+        <%= f.label t('moments.form.strategies') %>
       </div>
 
       <div id ="strategies" class="display_none">
@@ -101,7 +101,7 @@
     <% if !@viewers.nil? && @viewers.length > 0 %>
     <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.viewers') %>
+        <%= f.label t('moments.form.viewers') %>
         <div class="align_right">
           <span class="yes_title" title="Allies who can view your moment"><i class="fa fa-question-circle"></i></span>
         </div>
@@ -116,7 +116,7 @@
 
      <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.allow_comments') %>
+        <%= f.label t('moments.form.allow_comments') %>
         <span class="yes_title smaller_margin_left" title="Only you and viewers can comment"><i class="fa fa-question-circle"></i></span>
         <div class="align_right">
           <%= f.check_box :comment %>
@@ -128,7 +128,7 @@
   <div class="table_cell vertical_align_top">
     <div class="field">
       <div class="label">
-        <%= f.label t('.describe'), for: 'moment_why' %>
+        <%= f.label t('moments.form.describe'), for: 'moment_why' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>
@@ -138,7 +138,7 @@
     </div>
     <div class="field">
       <div class="label">
-        <%= f.label t('.desired') %>
+        <%= f.label t('moments.form.desired') %>
       </div>
       <%= f.cktext_area :fix, class: 'no_title special_textarea ckeditor' %>
 

--- a/app/views/moments/index.html.erb
+++ b/app/views/moments/index.html.erb
@@ -2,7 +2,7 @@
 <% page_new new_moment_path %>
 
 <div class="subtitle">
-  <%= t('.subtitle') %>
+  <%= t('moments.index.subtitle') %>
 </div>
 
 <div class="spacer"></div>

--- a/app/views/moments/show.html.erb
+++ b/app/views/moments/show.html.erb
@@ -3,21 +3,21 @@
 
 <% if !@moment.why.blank? %>
   <p>
-    <div class="label"><%= label_tag t('.why') %></div>
+    <div class="label"><%= label_tag t('moments.show.why') %></div>
     <%= raw(@moment.why) %>
   </p>
 <% end %>
 
 <% if !@moment.fix.blank? %>
   <p>
-    <div class="label"><%= label_tag t('.fix') %></div>
+    <div class="label"><%= label_tag t('moments.show.fix') %></div>
     <%= raw(@moment.fix) %>
   </p>
 <% end %>
 
 <% if @moment.strategies.count > 0 %>
   <p>
-    <div class="label"><%= label_tag t('.strategies') %></div>
+    <div class="label"><%= label_tag t('moments.show.strategies') %></div>
     <% @moment.strategies.each do |item| %>
         <span class="notification_wrapper">
           <span class="tip_notifications_button link_style"><%= Strategy.where(id: item).first.name %></span><% if @moment.strategies.last != item %><%= ', ' %><% end %>

--- a/app/views/moods/_form.html.erb
+++ b/app/views/moods/_form.html.erb
@@ -1,13 +1,13 @@
 <%= form_for(@mood) do |f| %>
 <% if @mood.errors.any? %>
   <div class="error_explanation">
-    <%= t('.error_explanation') %>
+    <%= t('moods.form.error_explanation') %>
   </div>
 <% end %>
 
   <div class="field">
     <div class="label">
-      <%= f.label t('.name'), for: 'mood_name' %>
+      <%= f.label t('moods.form.name'), for: 'mood_name' %>
       <i class="fa fa-exclamation-circle align_right"></i>
       <div class="clear"></div>
     </div>
@@ -16,7 +16,7 @@
 
   <div class="field">
     <div class="label">
-      <%= f.label t('.description'), for: 'mood_description' %>
+      <%= f.label t('moods.form.description'), for: 'mood_description' %>
     </div>
     <%= f.cktext_area :description, class: 'no_title special_textarea ckeditor' %>
   </div>

--- a/app/views/moods/index.html.erb
+++ b/app/views/moods/index.html.erb
@@ -2,7 +2,7 @@
 <% page_new new_mood_path %>
 
 <div class="subtitle">
-  <%= t('.subtitle') %>
+  <%= t('moods.index.subtitle') %>
 </div>
 
 <div class="spacer"></div>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,5 +1,5 @@
 <% title 'About' %>
-<%= t('.app_name') %> is a community for mental health experiences that encourages people to share their personal stories with trusted allies. Trusted allies are the people we interact with on a daily basis, including friends, family members, co-workers, teachers, and mental health workers.
+<%= t('app_name') %> is a community for mental health experiences that encourages people to share their personal stories with trusted allies. Trusted allies are the people we interact with on a daily basis, including friends, family members, co-workers, teachers, and mental health workers.
 
 <p>
 	Dealing with mental health is what makes us human. But for a lot of us, it's a struggle to be open about it.

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -20,7 +20,7 @@
 					<div class="align_right">
 	        			<h1 class="ally_name">
 	        				<% if current_user.id == story.userid %>
-	        					<%= link_to t('.you'), profile_index_path(uid: current_user.uid) %>
+	        					<%= link_to t('pages.home.you'), profile_index_path(uid: current_user.uid) %>
 	        				<% else %>
 	        					<%= link_to User.where(:id => story.userid).first.name, profile_index_path(uid: get_uid(story.userid)) %>
 	        				<% end %>

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -9,7 +9,7 @@
 			<div class="spacer"></div>
 		<% end %>
 		<% if @profile == current_user %>
-			<%= link_to t('.edit_user'), edit_user_registration_path %>
+			<%= link_to t('profile.index.edit_user'), edit_user_registration_path %>
 			<div class="spacer"></div>
 		<% end %>
 		<% if !User.where(:id => @profile.id).first.location.blank? %>
@@ -18,13 +18,13 @@
 		<% end %>
 		<% if @profile.id != current_user.id %>
 			<% if current_user.allies_by_status(:pending_from_ally).include? @profile %>
-			 	<br><%= link_to t('.cancel_request'), remove_allies_path(ally_id: @profile.id), :method => :post, data: { confirm: t('.confirm') } %>
+			 	<br><%= link_to t('profile.index.cancel_request'), remove_allies_path(ally_id: @profile.id), :method => :post, data: { confirm: t('profile.index.confirm') } %>
 			<% elsif current_user.allies_by_status(:accepted).include? @profile %>
-				<br><%= link_to t('.remove_ally'), remove_allies_path(ally_id: @profile.id), :method => :post, data: { confirm: t('.confirm') } %>
+				<br><%= link_to t('profile.index.remove_ally'), remove_allies_path(ally_id: @profile.id), :method => :post, data: { confirm: t('profile.index.confirm') } %>
 			<% elsif current_user.allies_by_status(:pending_from_user).include? @profile %>
-				<br><%= link_to t('.accept_ally'), add_allies_path(ally_id: @profile.id), :method => :post %> | <%= link_to t('.reject_ally'), remove_allies_path(:ally_id => @profile.id), :method => :post, data: { confirm: t('.confirm') } %>
+				<br><%= link_to t('profile.index.accept_ally'), add_allies_path(ally_id: @profile.id), :method => :post %> | <%= link_to t('profile.index.reject_ally'), remove_allies_path(:ally_id => @profile.id), :method => :post, data: { confirm: t('profile.index.confirm') } %>
 			<% else %>
-				<br><%= link_to t('.add_ally'), add_allies_path(ally_id: @profile.id), :method => :post %>
+				<br><%= link_to t('profile.index.add_ally'), add_allies_path(ally_id: @profile.id), :method => :post %>
 			<% end %>
 		<% end %>
 	</div>

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_for(:search, :url => search_index_path, :html => { :method => :get }) do |f| %>
     <% if @email.nil? %>
- 		<%= f.text_field :email, :placeholder => t('.search_by_email') %>
+ 		<%= f.text_field :email, :placeholder => t('search.form.search_by_email') %>
  	<% else %>
- 		<%= f.text_field :email, :placeholder => t('.search_by_email'), :value => @email %>
+ 		<%= f.text_field :email, :placeholder => t('search.form.search_by_email'), :value => @email %>
  	<% end %>
 
-    <%= f.submit t('.search'), class: 'no_margin_right' %>
+    <%= f.submit t('search.form.search'), class: 'no_margin_right' %>
 <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -26,13 +26,13 @@
 	       		<div class="clear"></div>
 
 	       		<% if current_user.allies_by_status(:pending_from_ally).include?(user) %>
-			        <%= link_to t('.cancel_request'), remove_allies_path(ally_id: user.id), :method => :post, data: { confirm: t('.confirm') } %>
+			        <%= link_to t('search.index.cancel_request'), remove_allies_path(ally_id: user.id), :method => :post, data: { confirm: t('search.index.confirm') } %>
 			    <% elsif current_user.allies_by_status(:pending_from_user).include?(user) %>
-			    	<%= link_to t('.accept_ally'), add_allies_path(ally_id: user.id), :method => :post %>
+			    	<%= link_to t('search.index.accept_ally'), add_allies_path(ally_id: user.id), :method => :post %>
 			    <% elsif current_user.allies_by_status(:accepted).include?(user) %>
-			        <%= link_to t('.remove_ally'), remove_allies_path(ally_id: user.id), :method => :post, data: { confirm: t('.confirm') } %>
+			        <%= link_to t('search.index.remove_ally'), remove_allies_path(ally_id: user.id), :method => :post, data: { confirm: t('search.index.confirm') } %>
 			    <% else %>
-			    	<%= link_to t('.add_ally'), add_allies_path(ally_id: user.id), :method => :post %>
+			    	<%= link_to t('search.index.add_ally'), add_allies_path(ally_id: user.id), :method => :post %>
 			    <% end %>
 			</div>
 		</div>

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -1,4 +1,4 @@
-<% if ((local_assigns[:comment_type] == 'moment' || local_assigns[:comment_type] == 'strategy') && local_assigns[:data].comment && (current_user.id == local_assigns[:data].userid || local_assigns[:no_hide_page])) || 
+<% if ((local_assigns[:comment_type] == 'moment' || local_assigns[:comment_type] == 'strategy') && local_assigns[:data].comment && (current_user.id == local_assigns[:data].userid || local_assigns[:no_hide_page])) ||
   (local_assigns[:comment_type] == 'meeting' && local_assigns[:is_member]) %>
 
   <div class="divider"></div>
@@ -7,7 +7,7 @@
   <%= form_for local_assigns[:comment], :url => { :action => "comment" }, :html => { :method => "post" } do |f| %>
     <% if local_assigns[:comment].errors.any? %>
         <div class="error_explanation">
-          <%= t('.error_explanation') %>
+          <%= t('shared.comments.error_explanation') %>
         </div>
     <% end %>
 
@@ -25,14 +25,14 @@
       <%= f.hidden_field :comment_by, :value => current_user.id %>
       <%= f.hidden_field :commented_on, :value => local_assigns[:data].id %>
       <% if (local_assigns[:comment_type] == 'moment' || local_assigns[:comment_type] == 'strategy') && local_assigns[:data].userid != current_user.id %>
-        <%= f.select :visibility, [[t('.share_everyone'), 'all'], [t('.share_with') + User.where(:id => local_assigns[:data].userid).first.name + t('.only'), 'private']] %>
+        <%= f.select :visibility, [[t('shared.comments.share_everyone'), 'all'], [t('shared.comments.share_with') + User.where(:id => local_assigns[:data].userid).first.name + t('shared.comments.only'), 'private']] %>
       <% else %>
         <%= f.hidden_field :visibility, :value => 'all' %>
         <% if (local_assigns[:comment_type] == 'moment' || local_assigns[:comment_type] == 'strategy') && !local_assigns[:data].viewers.blank? && local_assigns[:data].viewers.length > 0 %>
-         <%= f.select :viewers, local_assigns[:data].viewers.collect {|v| [ t('.share_with') + User.where(id: v).first.name + t('.only'), v ] }, { include_blank: t('.share_everyone') } %>
+         <%= f.select :viewers, local_assigns[:data].viewers.collect {|v| [ t('shared.comments.share_with') + User.where(id: v).first.name + t('shared.comments.only'), v ] }, { include_blank: t('shared.comments.share_everyone') } %>
         <% end %>
       <% end %>
-      <%= f.submit t('.comment'), class: 'no_margin_right small_margin_top', id: 'add_comment_button' %>
+      <%= f.submit t('shared.comments.comment'), class: 'no_margin_right small_margin_top', id: 'add_comment_button' %>
     </div>
 
     <div class="clear"></div>
@@ -40,14 +40,14 @@
 
   <div id="comments">
   <% local_assigns[:comments].each do |comment| %>
-    <% if comment.visibility == 'all' || 
-      (comment.visibility == 'private' && User.where(id: comment.comment_by).exists? && 
+    <% if comment.visibility == 'all' ||
+      (comment.visibility == 'private' && User.where(id: comment.comment_by).exists? &&
         (comment.comment_by == current_user.id ||
-        local_assigns[:is_member] ||  
-        current_user.id == local_assigns[:data].userid || 
+        local_assigns[:is_member] ||
+        current_user.id == local_assigns[:data].userid ||
         (!comment.viewers.blank? && comment.viewers.include?(current_user.id))
         )) %>
-        <% result = generate_comment(comment, comment.comment_type) %> 
+        <% result = generate_comment(comment, comment.comment_type) %>
         <% if local_assigns[:comments].first == comment %>
         <div class="comment no_margin_top" id=<%= 'comment_' + comment.id.to_s %>>
         <% else %>
@@ -72,7 +72,7 @@
           </div>
         </div>
       <% end %>
-  <% end %>  
+  <% end %>
   </div>
   </div>
 <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,28 +3,28 @@
 			<div class="table">
 				<div class="row">
 					<div class="table_cell large_padding_right">
-						<span class="footer_heading" id="if_me_links"><%= t('.app_name') %></span>
-						<%= link_to(t('.footer_about'), about_path) %>
-						<%= link_to(t('.footer_blog'), blog_path) %>
-						<%= link_to(t('.footer_contributors'), contributors_path) %>
-						<%= link_to(t('.faq'), faq_path) %>
-						<%= link_to(t('.footer_privacy'), privacy_path) %>
+						<span class="footer_heading" id="if_me_links"><%= t('app_name') %></span>
+						<%= link_to(t('shared.footer.footer_about'), about_path) %>
+						<%= link_to(t('shared.footer.footer_blog'), blog_path) %>
+						<%= link_to(t('shared.footer.footer_contributors'), contributors_path) %>
+						<%= link_to(t('shared.footer.faq'), faq_path) %>
+						<%= link_to(t('shared.footer.footer_privacy'), privacy_path) %>
 					</div>
 					<div class="table_cell">
-						<span class="footer_heading" id="connect_links"><%= t('.connect') %></span>
-						<%= link_to(t('.github'), "https://github.com/julianguyen/ifme", target: "blank") %>
-						<%= link_to(t('.twitter'), "http://twitter.com/ifmeorg", target: "blank") %>
-						<%= link_to(t('.patreon'), 'http://patreon.com/ifme', target: "blank") %>
-						<%= link_to(t('.email'), 'mailto:join.ifme@gmail.com') %>
+						<span class="footer_heading" id="connect_links"><%= t('shared.footer.connect') %></span>
+						<%= link_to(t('shared.footer.github'), "https://github.com/julianguyen/ifme", target: "blank") %>
+						<%= link_to(t('shared.footer.twitter'), "http://twitter.com/ifmeorg", target: "blank") %>
+						<%= link_to(t('shared.footer.patreon'), 'http://patreon.com/ifme', target: "blank") %>
+						<%= link_to(t('shared.footer.email'), 'mailto:join.ifme@gmail.com') %>
 					</div>
 				</div>
 			</div>
 			<div class="spacer"></div>
 			<div class="align_left">
-				<%= link_to(t('.feedback'), "http://goo.gl/forms/8EqoJDDiXY", class: "highlight", target: "blank", id: "feedback") %>
+				<%= link_to(t('shared.footer.feedback'), "http://goo.gl/forms/8EqoJDDiXY", class: "highlight", target: "blank", id: "feedback") %>
 			</div>
 			<div class="align_right">
-				<%= t('.copyright') %> &#169; <%= Time.now.strftime("%Y") %> <%= t('.app_name') %>
+				<%= t('shared.footer.copyright') %> &#169; <%= Time.now.strftime("%Y") %> <%= t('app_name') %>
 			</div>
 			<div class="clear"></div>
 		</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,21 +9,21 @@
 
       <ul id="small_nav" class="display_none">
       <% if user_signed_in? %>
-          <%= nav_link_to(t('.moments'), moments_path) %>
-          <%= nav_link_to(t('.categories'), categories_path) %>
-          <%= nav_link_to(t('.moods'), moods_path) %>
-          <%= nav_link_to(t('.strategies'), strategies_path) %>
-          <%= nav_link_to(t('.medications'), medications_path) %>
-          <%= nav_link_to(t('.groups'), groups_path) %>
-          <%= nav_link_to(t('.allies'), allies_path) %>
+          <%= nav_link_to(t('shared.header.moments'), moments_path) %>
+          <%= nav_link_to(t('shared.header.categories'), categories_path) %>
+          <%= nav_link_to(t('shared.header.moods'), moods_path) %>
+          <%= nav_link_to(t('shared.header.strategies'), strategies_path) %>
+          <%= nav_link_to(t('shared.header.medications'), medications_path) %>
+          <%= nav_link_to(t('shared.header.groups'), groups_path) %>
+          <%= nav_link_to(t('shared.header.allies'), allies_path) %>
           <div class="divider"></div>
-          <%= nav_link_to(t('.notifications'), "", class: 'notifications_button') %>
-          <%= nav_link_to(t('.profile'), profile_index_path(uid: current_user.uid)) %>
-          <%= nav_link_to(t('.account'), edit_user_registration_path) %>
-          <%= nav_link_to(t('.signout'), destroy_user_session_path, :method => :delete) %>
+          <%= nav_link_to(t('shared.header.notifications'), "", class: 'notifications_button') %>
+          <%= nav_link_to(t('shared.header.profile'), profile_index_path(uid: current_user.uid)) %>
+          <%= nav_link_to(t('shared.header.account'), edit_user_registration_path) %>
+          <%= nav_link_to(t('shared.header.signout'), destroy_user_session_path, :method => :delete) %>
         <% else %>
-          <%= nav_link_to(t('.signin'), new_user_session_path) %>
-          <%= nav_link_to(t('.join'), new_user_registration_path) %>
+          <%= nav_link_to(t('shared.header.signin'), new_user_session_path) %>
+          <%= nav_link_to(t('shared.header.join'), new_user_registration_path) %>
         <% end %>
       </ul>
     </div>
@@ -33,29 +33,29 @@
 
       <ul class="top-nav primary-nav">
         <% if user_signed_in? %>
-          <%= nav_link_to(t('.home'), root_path)  %>
-          <%= nav_link_to(t('.moments'), moments_path, :class => "expand_moment_button") %>
-          <%= nav_link_to(t('.strategies'), strategies_path) %>
-          <%= nav_link_to(t('.medications'), medications_path) %>
-          <%= nav_link_to(t('.groups'), groups_path) %>
-          <%= nav_link_to(t('.allies'), allies_path) %>
+          <%= nav_link_to(t('shared.header.home'), root_path)  %>
+          <%= nav_link_to(t('shared.header.moments'), moments_path, :class => "expand_moment_button") %>
+          <%= nav_link_to(t('shared.header.strategies'), strategies_path) %>
+          <%= nav_link_to(t('shared.header.medications'), medications_path) %>
+          <%= nav_link_to(t('shared.header.groups'), groups_path) %>
+          <%= nav_link_to(t('shared.header.allies'), allies_path) %>
         <% else %>
-          <%= nav_link_to(t('.signin'), new_user_session_path) %>
-          <%= nav_link_to(t('.join'), new_user_registration_path) %>
+          <%= nav_link_to(t('shared.header.signin'), new_user_session_path) %>
+          <%= nav_link_to(t('shared.header.join'), new_user_registration_path) %>
         <% end %>
       </ul>
 
       <% if user_signed_in? %>
         <ul id="expand_moment" class="top-nav display_none">
-          <%= nav_link_to(t('.categories'), categories_path) %>
-          <%= nav_link_to(t('.moods'), moods_path) %>
+          <%= nav_link_to(t('shared.header.categories'), categories_path) %>
+          <%= nav_link_to(t('shared.header.moods'), moods_path) %>
         </ul>
 
         <ul id="expand_me" class="top-nav large-screen display_none">
-          <%= nav_link_to(t('.notifications'), "", class: 'notifications_button') %>
-          <%= nav_link_to(t('.profile'), profile_index_path(uid: current_user.uid)) %>
-          <%= nav_link_to(t('.account'), edit_user_registration_path) %>
-          <%= nav_link_to(t('.signout'), destroy_user_session_path, :method => :delete) %>
+          <%= nav_link_to(t('shared.header.notifications'), "", class: 'notifications_button') %>
+          <%= nav_link_to(t('shared.header.profile'), profile_index_path(uid: current_user.uid)) %>
+          <%= nav_link_to(t('shared.header.account'), edit_user_registration_path) %>
+          <%= nav_link_to(t('shared.header.signout'), destroy_user_session_path, :method => :delete) %>
         </ul>
       <% end %>
     </div>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -14,9 +14,9 @@
 		<% end %>
 		<div class="small_margin_bottom">
 			<% if !local_assigns[:profile] || local_assigns[:profile] == current_user.id %>
-				<%= 'You are' + t('.most_focus') %>
+				<%= 'You are' + t('shared.stats.most_focus') %>
 			<% elsif local_assigns[:profile] %>
-				<%= User.where(id: local_assigns[:profile]).first.name + ' is ' + t('.most_focus') %>
+				<%= User.where(id: local_assigns[:profile]).first.name + ' is ' + t('shared.stats.most_focus') %>
 			<% end %>
 		</div>
 

--- a/app/views/shared/_viewers_indicator.html.erb
+++ b/app/views/shared/_viewers_indicator.html.erb
@@ -1,17 +1,17 @@
 <div class="viewers_indicator">
 <% if !local_assigns[:data].viewers.blank? %>
 	<% if local_assigns[:data].viewers.length == 1  && local_assigns[:data].viewers.length[0] != current_user.id && local_assigns[:data].userid != current_user.id %>
-	<%= raw t('.only_viewer') %>
+	<%= raw t('shared.viewers_indicator.only_viewer') %>
 	<% elsif local_assigns[:data].viewers.length > 0 && local_assigns[:data].userid != current_user.id %>
-	<%= raw t('.not_only_viewer') %>
+	<%= raw t('shared.viewers_indicator.not_only_viewer') %>
 	<% elsif local_assigns[:data].userid == current_user.id %>
 		<% result = '' %>
 		<% local_assigns[:data].viewers.each do |viewer| %>
 			<% name = User.where(id: viewer).first.name %>
 			<% if local_assigns[:data].viewers.last == viewer && local_assigns[:data].viewers.length > 1 &&  local_assigns[:data].viewers.length == 2 %>
-				<% result += t('.and') + name %>
+				<% result += t('shared.viewers_indicator.and') + name %>
 			<% elsif local_assigns[:data].viewers.last == viewer && local_assigns[:data].viewers.length > 1 &&  local_assigns[:data].viewers.length != 2 %>
-				<% result +=  t('.comma_and') + name %>
+				<% result +=  t('shared.viewers_indicator.comma_and') + name %>
 			<% elsif local_assigns[:data].viewers.last != viewer && local_assigns[:data].viewers.length != 2 && viewer != local_assigns[:data].viewers.first %>
 				<% result +=  ', ' + name %>
 			<% else %>
@@ -20,15 +20,15 @@
 		<% end %>
 		<%= result %>
 		<% if local_assigns[:data].viewers.length > 1 %>
-		<%= t('.are_viewers') %>
+		<%= t('shared.viewers_indicator.are_viewers') %>
 		<% else %>
-		<%= t('.is_a_viewer.') %>
+		<%= t('shared.viewers_indicator.is_a_viewer.') %>
 		<% end %>
 	<% end %>
 <% else %>
-	<%= raw t('.no_viewers') %>
+	<%= raw t('shared.viewers_indicator.no_viewers') %>
 <% end %>
 <% if !local_assigns[:data].comment %>
-	<%= t('.disabled_comments') %>
+	<%= t('shared.viewers_indicator.disabled_comments') %>
 <% end %>
 </div>

--- a/app/views/strategies/_form.html.erb
+++ b/app/views/strategies/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(@strategy) do |f| %>
 <% if @strategy.errors.any? %>
   <div class="error_explanation">
-    <%= t('.error_explanation') %>
+    <%= t('strategies.form.error_explanation') %>
   </div>
 <% end %>
 
@@ -11,7 +11,7 @@
 
     <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.name'), for: 'strategy_name' %>
+        <%= f.label t('strategies.form.name'), for: 'strategy_name' %>
         <div class="align_right">
         <span class="yes_title" title="Any activity, train of thought, or form or self-care that helps you"><i class="fa fa-question-circle"></i></span>
         <i class="fa fa-exclamation-circle"></i>
@@ -29,7 +29,7 @@
         <a href="#" class="toggle_button display_none" id="hideCategories">
           <i class="fa fa-caret-up" ></i>
         </a>
-        <%= f.label t('.categories') %>
+        <%= f.label t('strategies.form.categories') %>
       </div>
       <div id="categories" class="display_none">
         <div id="categories_list">
@@ -50,7 +50,7 @@
     <% if !@viewers.nil? && @viewers.length > 0 %>
     <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.viewers') %>
+        <%= f.label t('strategies.form.viewers') %>
         <div class="align_right">
           <span class="yes_title" title="Allies who can view your strategy and tag their own moments with it"><i class="fa fa-question-circle"></i></span>
         </div>
@@ -65,7 +65,7 @@
 
     <div class="sidebar_field">
       <div class="sidebar_label">
-        <%= f.label t('.allow_comments') %>
+        <%= f.label t('strategies.form.allow_comments') %>
         <span class="yes_title smaller_margin_left" title="Only you and viewers can comment"><i class="fa fa-question-circle"></i></span>
         <div class="align_right">
           <%= f.check_box :comment %>
@@ -77,7 +77,7 @@
   <div class="table_cell vertical_align_top">
     <div class="field">
       <div class="label">
-        <%= f.label t('.describe'), for: 'strategy_description' %>
+        <%= f.label t('strategies.form.describe'), for: 'strategy_description' %>
         <i class="fa fa-exclamation-circle align_right"></i>
         <div class="clear"></div>
       </div>

--- a/app/views/strategies/index.html.erb
+++ b/app/views/strategies/index.html.erb
@@ -2,7 +2,7 @@
 <% page_new new_strategy_path %>
 
 <div class="subtitle">
-  <%= t('.subtitle') %>
+  <%= t('strategies.index.subtitle') %>
 </div>
 
 <div class="spacer"></div>

--- a/app/views/strategies/show.html.erb
+++ b/app/views/strategies/show.html.erb
@@ -1,12 +1,12 @@
 <% title @strategy.name %>
-<strong><%= t('.created') %></strong> <%= local_time_ago(@strategy.created_at) %>
+<strong><%= t('strategies.show.created') %></strong> <%= local_time_ago(@strategy.created_at) %>
 <% if @strategy.category.count > 0 %>
   <br>
     <strong>
       <% if @strategy.category.count == 1 %>
-        <%= t('.category') %>
+        <%= t('strategies.show.category') %>
       <% else %>
-        <%= t('.categories') %>
+        <%= t('strategies.show.categories') %>
       <% end %>
     </strong>
     <% @strategy.category.each do |item| %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,6 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
   #
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -333,8 +333,8 @@ en:
    unsupport: 'Unsupport'
    support: 'Support'
 
-   notifications:
-    members:
-      remove: 'Remove'
+ notifications:
+  members:
+    remove: 'Remove'
 
    #submit button

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,7 +229,6 @@ en:
     feedback: 'Feedback?'
     copyright: 'Copyright'
     faq: 'FAQ'
-    app_name: 'if me'
     connect: 'connect'
     email: 'Email'
   comments:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,8 +166,6 @@ en:
    premade5_description: 'Feeling sad and hopeless - unable to find any possible solutions'
 
  pages:
-  about:
-   app_name: 'if me'
   home:
    you: 'You'
    created: 'Created:'


### PR DESCRIPTION
This PR does a few things:
* Turn on exceptions for missing translations in dev and test
* Fixes the indentation for notifications in en.yml in order to fix a failing test
* Removes several app_name keys that were unnecessary
* Uses the fully qualified key names of all currently existing translated keys so that we can more easily identify areas of overlap, and find existing uses of keys
* Removes some whitespace from some files (my editor does that automatically, don't think it should be a problem)

Commits can be squashed after review.