### PR TITLE
spec for viewers indicators in a strategy spec; refactored viewer ind…

### DIFF
--- a/app/views/shared/_viewers_indicator.html.erb
+++ b/app/views/shared/_viewers_indicator.html.erb
@@ -1,34 +1,13 @@
 <div class="viewers_indicator">
-<% if !local_assigns[:data].viewers.blank? %>
-	<% if local_assigns[:data].viewers.length == 1  && local_assigns[:data].viewers.length[0] != current_user.id && local_assigns[:data].userid != current_user.id %>
-	<%= raw t('shared.viewers_indicator.only_viewer') %>
-	<% elsif local_assigns[:data].viewers.length > 0 && local_assigns[:data].userid != current_user.id %>
-	<%= raw t('shared.viewers_indicator.not_only_viewer') %>
-	<% elsif local_assigns[:data].userid == current_user.id %>
-		<% result = '' %>
-		<% local_assigns[:data].viewers.each do |viewer| %>
-			<% name = User.where(id: viewer).first.name %>
-			<% if local_assigns[:data].viewers.last == viewer && local_assigns[:data].viewers.length > 1 &&  local_assigns[:data].viewers.length == 2 %>
-				<% result += t('shared.viewers_indicator.and') + name %>
-			<% elsif local_assigns[:data].viewers.last == viewer && local_assigns[:data].viewers.length > 1 &&  local_assigns[:data].viewers.length != 2 %>
-				<% result +=  t('shared.viewers_indicator.comma_and') + name %>
-			<% elsif local_assigns[:data].viewers.last != viewer && local_assigns[:data].viewers.length != 2 && viewer != local_assigns[:data].viewers.first %>
-				<% result +=  ', ' + name %>
-			<% else %>
-				<% result +=  name %>
-			<% end %>
-		<% end %>
-		<%= result %>
-		<% if local_assigns[:data].viewers.length > 1 %>
-		<%= t('shared.viewers_indicator.are_viewers') %>
-		<% else %>
-		<%= t('shared.viewers_indicator.is_a_viewer.') %>
-		<% end %>
-	<% end %>
-<% else %>
-	<%= raw t('shared.viewers_indicator.no_viewers') %>
-<% end %>
-<% if !local_assigns[:data].comment %>
-	<%= t('shared.viewers_indicator.disabled_comments') %>
-<% end %>
+  <% viewers = local_assigns[:data].viewers %>
+  <% if local_assigns[:data].userid == current_user.id %>
+    <% viewer_names = viewers.map { |id| User.where(id: id).first.name } %>
+    <%= t('shared.viewers_indicator.viewers_html', count: viewers.count, names: viewer_names.to_sentence) %>
+  <% else %>
+    <%= t('shared.viewers_indicator.you_are_viewer_html', count: viewers.length) %>
+  <% end %>
+
+  <% if !local_assigns[:data].comment %>
+    <%= t('shared.viewers_indicator.disabled_comments') %>
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,11 +330,13 @@ en:
    moods: 'Moods'
   viewers_indicator:
    disabled_comments: 'Comments have been disabled.'
-   no_viewers: 'There are <strong>no</strong> viewers.'
-   only_viewer: 'You are the only viewer.'
-   not_only_viewer: 'You are <strong>not</strong> the only viewer.'
-   are_viewers: ' are viewers.'
-   is_a_viewer: ' is a viewer.'
+   you_are_viewer_html:
+    one: 'You are the only viewer.'
+    other: 'You are <strong>not</strong> the only viewer.'
+   viewers_html:
+     zero: 'There are <strong>no</strong> viewers.'
+     one: '%{names} is a viewer.'
+     other: '%{names} are viewers.'
    and: ' and '
    comma_and: ', and '
   stats:

--- a/spec/features/strategy_viewers_spec.rb
+++ b/spec/features/strategy_viewers_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.feature "UserViewsAStrategy", type: :feature do
+  let(:user) { create :user2 }
+
+  let!(:allies) do
+    viewer_count.times do |i|
+      ally = create :user1, name: "Ally #{i}"
+      create :allyships_accepted, user_id: user.id, ally_id: ally.id
+    end
+    user.allies_by_status(:accepted)
+  end
+
+  let!(:strategy) { create(:strategy, userid: user.id, viewers: allies.map(&:id)) }
+
+  feature 'Viewing a strategy' do
+    context 'as the strategy owner' do
+      before do
+        login_as user
+        visit strategy_path(strategy.id)
+      end
+
+      context 'with no other viewers' do
+        let(:viewer_count) { 0 }
+
+        it 'says there are no viewers' do
+          within '.viewers_indicator' do
+            expect(page).to have_content 'There are no viewers'
+          end
+        end
+      end
+
+      context 'with 1 other viewer' do
+        let(:viewer_count) { 1 }
+
+        it 'says there is one viewer' do
+          within '.viewers_indicator' do
+            expect(page).to have_content 'Ally 0 is a viewer'
+          end
+        end
+      end
+
+      context 'with 2 other viewers' do
+        let(:viewer_count) { 2 }
+
+        it 'says there are two viewers' do
+          within '.viewers_indicator' do
+            expect(page).to have_content 'Ally 0 and Ally 1 are viewers'
+          end
+        end
+      end
+
+      context 'with 3 other viewers' do
+        let(:viewer_count) { 3 }
+
+        it 'says there are three viewers' do
+          within '.viewers_indicator' do
+            expect(page).to have_content 'Ally 0, Ally 1, and Ally 2 are viewers'
+          end
+        end
+      end
+    end
+
+    context 'as one of the viewers' do
+      before do
+        login_as allies.first
+        visit strategy_path(strategy.id)
+      end
+
+      context 'when you are the only viewer' do
+        let(:viewer_count) { 1 }
+
+        it 'says you are the only viewer' do
+          within '.viewers_indicator' do
+            expect(page).to have_content 'You are the only viewer'
+          end
+        end
+      end
+
+      context 'when there are other viewers' do
+        let(:viewer_count) { 2 }
+
+        it 'says you are not the only viewer' do
+          within '.viewers_indicator' do
+            expect(page).to have_content 'You are not the only viewer.'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
…icators to be more i18n-friendly

I started this refactor by writing some acceptance tests for viewing a strategy, since that is one of the places where the viewer_indicator partial is used. I'm not crazy about testing a partial in this way but it seemed better than nothing so I would have a baseline to run tests against while I refactored. I was also trying to avoid using a helper since I thought the if/else blocks could be simplified enough for a view.

This also assumes that the controller will take care of permissions issues, which I think is fine (no need to check that, if you are not logged in as the strategy owner, that the ID of the one viewer matches the current_user's ID).