### PR TITLE
Display leader names correctly on group show page

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -19,7 +19,7 @@
     <%= t('groups.show.led_by') %>
   </strong>
 
-  <%= @group.leaders.map { |leader| leader_link(leader) }.to_sentence  %>
+  <%= @group.leaders.map { |leader| leader_link(leader) }.to_sentence.html_safe  %>
 
   <% if user_can_delete? @group %>
     <%= delete_group_link(@group, class: 'align_right') %>

--- a/spec/features/user_visits_group_show_spec.rb
+++ b/spec/features/user_visits_group_show_spec.rb
@@ -2,15 +2,18 @@ RSpec.feature "UserVisitsGroupsPages", type: :feature do
   feature 'User vists groups page' do
     scenario 'successfully' do
       user = create :user1
+      leader = create :user2
       login_as user
       group = create :group_with_member, userid: user.id
       meeting = create :meeting, groupid: group.id
       create :meeting_member, userid: user.id, meetingid: meeting.id
+      create :group_leader, userid: leader.id, groupid: group.id
 
       visit group_path(group)
 
       expect(page.title).to match group.name
       expect(page).to have_content group.name
+      expect(page).to have_content "Led by: #{leader.name}"
     end
   end
 end


### PR DESCRIPTION
When browsing the app I noticed that group leader names were displaying as raw html instead of actual links on the group show page. So it would display as 

`"Led by: <a href=user_show_path>User</a>" `

I modified the user_visits_group_show spec to test that the names would display correctly and added .html_safe to the group show page so that the links would display as intended.