### PR TITLE
Form field to add refill onto Google Calendar

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -58,7 +58,7 @@ class MedicationsController < ApplicationController
     respond_to do |format|
       if @medication.save
         # Save refill date to Google calendar
-        if (!current_user.token.blank?)
+        if current_user.google_oauth2_enabled? && params[:add_to_google_cal]
           summary = "Refill for " + @medication.name
           date = @medication.refill
           CalendarUploader.new(summary: summary, date: date, access_token: current_user.token, email: current_user.email).upload_event
@@ -139,7 +139,7 @@ class MedicationsController < ApplicationController
     def medication_params
       params.require(:medication).permit(
         :name, :dosage, :refill, :userid, :total, :strength, :dosage_unit,
-        :total_unit, :strength_unit, :comments,
+        :total_unit, :strength_unit, :comments, :add_to_google_cal,
         { take_medication_reminder_attributes: [:active, :id] }, { refill_reminder_attributes: [:active, :id] }
       )
     end

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -34,4 +34,6 @@ class Medication < ActiveRecord::Base
   validates :dosage, :numericality => { :greater_than_or_equal_to => 0 }
   validates :total, :numericality => { :greater_than_or_equal_to => 0 }
   validates :strength, :numericality => { :greater_than_or_equal_to => 0 }
+
+  attr_accessor :add_to_google_cal
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,6 +88,10 @@ class User < ActiveRecord::Base
      ally_groups.order(order) - groups
    end
 
+   def google_oauth2_enabled?
+     !token.blank?
+   end
+
    private
 
    def accepted_ally_ids

--- a/app/views/medications/_form.html.erb
+++ b/app/views/medications/_form.html.erb
@@ -124,11 +124,27 @@
           </div>
           <div class="align_right">
             <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title', title: t('medications.form.daily_reminder_hint')) %>
+            <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title', title: t('medications.form.add_to_google_cal')) %>
           </div>
           <div class="clear"></div>
         </div>
       <% end %>
     </div>
+
+    <% if current_user.google_oauth2_enabled? %>
+      <div class="field">
+        <div class="inline-block">
+          <%= f.check_box :add_to_google_cal %>
+          <div class="label">
+            <%= f.label t('.add_to_google_cal') %>
+            <div class="align_right">
+              <span class="yes_title" title="Adds a reminder for this medication onto your Google Calendar"><i class="fa fa-question-circle"></i></span>
+            </div>
+          </div>
+          <div class="clear"></div>
+        </div>
+      </div>
+    <% end %>
 
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,6 +155,7 @@ en:
    refill_reminder: 'Refill reminder email'
    error_explanation: 'Please fill out the marked fields!'
    comments_hint: 'Additional comments, log your symptoms here'
+   add_to_google_cal: 'Save to Google Calendar?'
    strength_hint: 'Medication strength, usually found beside the name'
    total_hint: 'Total number of pills or amount of medication'
    dosage_hint: 'Number of pills or servings daily'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -90,6 +90,15 @@ FactoryGirl.define do
     timezone "-05:00"
   end
 
+  factory :user_oauth, class: User do
+    name "Orange Southland"
+    email "orange.southland@example.com"
+    password "password"
+    location "Toronto, ON, Canada"
+    timezone "-05:00"
+    token "has_a_token"
+  end
+
   factory :allyships_accepted, class: Allyship do
     status :accepted
   end

--- a/spec/features/adding_medication_spec.rb
+++ b/spec/features/adding_medication_spec.rb
@@ -1,5 +1,5 @@
 describe "user adds a new medication" do
-  let!(:user) { FactoryGirl.create(:user1) }
+  let!(:user) { FactoryGirl.create(:user_oauth) }
   before do
     login_as user
     visit new_medication_path
@@ -37,5 +37,21 @@ describe "user adds a new medication" do
       expect(new_medication.refill_reminder.active?).to eq(true)
     end
   end
-end
 
+  it "creates a new medication with Google Calendar reminder" do
+    fill_in "Name", with: "A medication name"
+    fill_in "medication_comments", with: "A comment"
+    fill_in "Strength", with: 100
+    fill_in "Total", with: 30
+    fill_in "Dosage", with: 30
+    fill_in "Refill", with: "05/25/2016"
+    find(:css, "#take_medication_reminder").set(true)
+    find(:css, "#refill_reminder").set(true)
+    find(:css, "#medication_add_to_google_cal").set(true)
+    click_on "Create Medication"
+    expect(page).to have_content("A medication name")
+    new_medication = user.medications.last
+    expect(new_medication.take_medication_reminder.active?).to eq(true)
+    expect(new_medication.refill_reminder.active?).to eq(true)
+  end
+end


### PR DESCRIPTION
This pull request will add a form field for users to switch on weather they want to add medication refills to Google Calendar (for those that used omniauth to join).

Originally users that used omniauth to sign up would automatically have medication refills added their Google Calendar. This now adds them only if the user has checked the "Add to Google Calendar" checkbox.

This is my first pull request to the if-me project, so, let me know if I missed anything when doing this work. Thanks!