### PR TITLE
UI/UX improvements

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -66,61 +66,12 @@ var onReadyApplication = function() {
 	$('.yes_title').find(':not(.no_title)').tooltip();
 
 	if (newOrEdit(['moments', 'strategies'])) {
-
-		$('#showCategories').click(function(event) {
+		$('.expand_toggle').click(function(event){
+			var toggleID = $(this).data('toggle');
+			$(toggleID).toggle();
+			$(this).find('.toggle_button i').toggleClass('fa-caret-down');
+			$(this).find('.toggle_button i').toggleClass('fa-caret-up');
 			event.preventDefault();
-			$('#categories').css({"display": "block"});
-			$('#showCategories').css({"display": "none"});
-			$('#hideCategories').css({"display": "block"});
-		});
-
-		$('#hideCategories').click(function(event) {
-			event.preventDefault();
-			$('#categories').css({"display": "none"});
-			$('#showCategories').css({"display": "block"});
-			$('#hideCategories').css({"display": "none"});
-		});
-
-		$('#showMoods').click(function(event) {
-			event.preventDefault();
-			$('#moods').css({"display": "block"});
-			$('#showMoods').css({"display": "none"});
-			$('#hideMoods').css({"display": "block"});
-		});
-
-		$('#hideMoods').click(function(event) {
-			event.preventDefault();
-			$('#moods').css({"display": "none"});
-			$('#showMoods').css({"display": "block"});
-			$('#hideMoods').css({"display": "none"});
-		});
-
-		$('#showStrategies').click(function(event) {
-			event.preventDefault();
-			$('#strategies').css({"display": "block"});
-			$('#showStrategies').css({"display": "none"});
-			$('#hideStrategies').css({"display": "block"});
-		});
-
-		$('#hideStrategies').click(function(event) {
-			event.preventDefault();
-			$('#strategies').css({"display": "none"});
-			$('#showStrategies').css({"display": "block"});
-			$('#hideStrategies').css({"display": "none"});
-		});
-
-		$('#showViewers').click(function(event) {
-			event.preventDefault();
-			$('#viewers').css({"display": "block"});
-			$('#showViewers').css({"display": "none"});
-			$('#hideViewers').css({"display": "block"});
-		});
-
-		$('#hideViewers').click(function(event) {
-			event.preventDefault();
-			$('#viewers').css({"display": "none"});
-			$('#showViewers').css({"display": "block"});
-			$('#hideViewers').css({"display": "none"});
 		});
 	}
 };

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -708,7 +708,15 @@ input[type="submit"]:hover {
 }
 
 .sidebar_label label, .sidebar_label {
-  font-size: 24px;
+	font-size: 24px;
+}
+
+.sidebar_label.expand_toggle label {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	cursor: pointer;
 }
 
 .special_textarea {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -318,6 +318,10 @@ ul.no_bullet_list li {
 	width: auto;
 }
 
+.yes_title {
+	cursor: help;
+}
+
 /* Page Title */
 
 #page_title {

--- a/app/assets/stylesheets/application/notifications.scss
+++ b/app/assets/stylesheets/application/notifications.scss
@@ -13,6 +13,7 @@
   background: linear-gradient(90deg, $background-color 97%, $transparent 3%);
   width: 50%;
   position: fixed;
+  z-index: 20;
 
   @media screen and (max-width: $small) {
     width: 90%;
@@ -68,7 +69,8 @@
   margin: 0 auto;
   width: 50%;
   max-height: 350px;
-  overflow: scroll;
+  overflow-x: hidden;
+  overflow-y: auto;
   border: 1px solid $container-color;
   box-shadow: 0 0 10px $container-color;
   background-color: $background-color;

--- a/app/views/moments/_form.html.erb
+++ b/app/views/moments/_form.html.erb
@@ -19,15 +19,13 @@
     </div>
 
     <div class="sidebar_field">
-      <div class="sidebar_label">
-        <a href="#" class="toggle_button" id="showCategories">
+      <div class="sidebar_label expand_toggle" data-toggle="#categories">
+        <a href="#" class="toggle_button">
           <i class="fa fa-caret-down"></i>
         </a>
-        <a href="#" class="toggle_button display_none" id="hideCategories">
-          <i class="fa fa-caret-up" ></i>
-        </a></i>
         <%= f.label t('moments.form.categories') %>
       </div>
+
       <div id="categories" class="display_none">
         <div id="categories_list">
         <% if !@categories.nil? && @categories.length > 0 %>
@@ -45,12 +43,9 @@
     </div>
 
     <div class="sidebar_field">
-      <div class="sidebar_label">
-        <a href="#" class="toggle_button" id="showMoods">
+      <div class="sidebar_label expand_toggle" data-toggle="#moods">
+        <a href="#" class="toggle_button">
           <i class="fa fa-caret-down"></i>
-        </a>
-        <a href="#" class="toggle_button display_none" id="hideMoods">
-          <i class="fa fa-caret-up" ></i>
         </a>
         <%= f.label t('moments.form.moods') %>
       </div>
@@ -72,12 +67,9 @@
     </div>
 
     <div class="sidebar_field">
-      <div class="sidebar_label">
-        <a href="#" class="toggle_button" id="showStrategies">
+      <div class="sidebar_label expand_toggle" data-toggle="#strategies">
+        <a href="#" class="toggle_button">
           <i class="fa fa-caret-down"></i>
-        </a>
-        <a href="#" class="toggle_button display_none" id="hideStrategies">
-          <i class="fa fa-caret-up" ></i>
         </a>
         <%= f.label t('moments.form.strategies') %>
       </div>
@@ -100,12 +92,9 @@
 
     <% if !@viewers.nil? && @viewers.length > 0 %>
     <div class="sidebar_field">
-      <div class="sidebar_label">
-        <a href="#" class="toggle_button" id="showViewers">
+      <div class="sidebar_label expand_toggle" data-toggle="#viewers">
+        <a href="#" class="toggle_button">
           <i class="fa fa-caret-down"></i>
-        </a>
-        <a href="#" class="toggle_button display_none" id="hideViewers">
-          <i class="fa fa-caret-up" ></i>
         </a>
         <%= f.label t('moments.form.viewers') %>
         <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title smaller_margin_left', title: t('moments.form.viewers_hint')) %>

--- a/app/views/strategies/_form.html.erb
+++ b/app/views/strategies/_form.html.erb
@@ -22,15 +22,13 @@
     </div>
 
     <div class="sidebar_field">
-      <div class="sidebar_label">
-        <a href="#" class="toggle_button" id="showCategories">
+      <div class="sidebar_label expand_toggle" data-toggle="#categories">
+        <a href="#" class="toggle_button">
           <i class="fa fa-caret-down"></i>
-        </a>
-        <a href="#" class="toggle_button display_none" id="hideCategories">
-          <i class="fa fa-caret-up" ></i>
         </a>
         <%= f.label t('strategies.form.categories') %>
       </div>
+      
       <div id="categories" class="display_none">
         <div id="categories_list">
         <% if !@categories.nil? && @categories.length > 0 %>
@@ -49,12 +47,9 @@
 
     <% if !@viewers.nil? && @viewers.length > 0 %>
     <div class="sidebar_field">
-      <div class="sidebar_label">
-        <a href="#" class="toggle_button" id="showViewers">
+      <div class="sidebar_label expand_toggle" data-toggle="#viewers">
+        <a href="#" class="toggle_button">
           <i class="fa fa-caret-down"></i>
-        </a>
-        <a href="#" class="toggle_button display_none" id="hideViewers">
-          <i class="fa fa-caret-up" ></i>
         </a>
         <%= f.label t('strategies.form.viewers') %>
         <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title smaller_margin_left', title: t('strategies.form.viewers_hint')) %>

--- a/spec/features/user_creates_moment_spec.rb
+++ b/spec/features/user_creates_moment_spec.rb
@@ -26,22 +26,22 @@ describe "UserCreatesAMoment", js: true do
 
       page.fill_in "moment[name]", with: "My new moment"
 
-      page.find('#showCategories').click
+      page.find('[data-toggle="#categories"]').click
 
       within '#categories_list' do
         page.find('input[type=checkbox]').click
       end
 
-      page.find('#showMoods').click
+      page.find('[data-toggle="#moods"]').click
       within '#moods_list' do
         page.find('input[type=checkbox]').click
       end
 
-      scroll_to_and_click('#showStrategies')
+      scroll_to_and_click('[data-toggle="#strategies"]')
 
       scroll_to_and_click('#strategies_list input[type=checkbox]')
 
-      scroll_to_and_click('#showViewers')
+      scroll_to_and_click('[data-toggle="#viewers"]')
       within '#viewers_list' do
         scroll_to_and_click('input#viewers_all')
       end

--- a/spec/features/user_creates_strategy_spec.rb
+++ b/spec/features/user_creates_strategy_spec.rb
@@ -24,13 +24,13 @@ describe "UserCreatesAStrategy", js: true do
 
       page.fill_in "strategy[name]", with: "My new strategy"
 
-      page.find('#showCategories').click
+      page.find('[data-toggle="#categories"]').click
 
       within '#categories_list' do
         page.find('input[type=checkbox]').click
       end
 
-      page.find('#showViewers').click
+      page.find('[data-toggle="#viewers"]').click
       within '#viewers_list' do
         page.find('input#viewers_all').click
       end


### PR DESCRIPTION
- Refactor expanding tabs

Labels in `/strategies/new` and `/moments/new` forms are now clickable and can expand tabs in sidebar. Small carets were pretty hard to click. I think clickable labels are more intuitive and makes app easier to use. I made expand code smaller and more scalable.

- Fix bugs in pop-ups

There was a bug with scrollbars in pop-ups:

![before](https://cloud.githubusercontent.com/assets/6865958/19015797/b947894a-880b-11e6-977e-ee9437fa06ca.png)

which now look better:

![screenshot at 19-19-48](https://cloud.githubusercontent.com/assets/6865958/19015812/0ef1f452-880c-11e6-9150-6ba98942f5ea.png)

Also, the asterisk was shown above titlebar. This was weird so I fixed it.

- Add hover effect to tooltip icons 

Cursor is changed to question mark. 


