### PR TITLE
Make i18n text in mailer HTML safe

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -9,13 +9,13 @@
    		<p>
         <%= t('layouts.mailer.html.app_description',
               app_name: link_to(t('app_name'), root_url)
-        ) %>
+        ).html_safe %>
    		</p>
 
 		<p>
       <%= t('layouts.mailer.html.no_reply',
             email: link_to(t('email'), "mailto:join.ifme@gmail.com")
-      ) %>
+      ).html_safe %>
 		</p>
   	</body>
 </html>


### PR DESCRIPTION
A quick hack to fix #286 (raw HTML in the email footer) :metal: 

<img width="1197" alt="screen shot 2016-10-01 at 8 10 34 pm" src="https://cloud.githubusercontent.com/assets/121322/19018373/2a4841d2-8813-11e6-99c3-8811b1ed29db.png">

