### PR TITLE
Email reminders to meeting members [#131]

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -61,7 +61,8 @@ class PagesController < ApplicationController
       {name: 'Jon Friestedt', link: 'https://github.com/jfriestedt'},
       {name: 'Andy Fry', link: 'https://github.com/andyfry01'},
       {name: 'Yigit Ozkavci', link: 'https://github.com/yigitozkavci'},
-      {name: 'Karol Musur', link: 'https://github.com/Wowu'}
+      {name: 'Karol Musur', link: 'https://github.com/Wowu'},
+      {name: 'Tim Downey', link: 'http://downey.io'}
     ]
 
     @contributors.sort_by!{ |c| c[:name].downcase }

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -17,6 +17,14 @@ class NotificationMailer < ApplicationMailer
          subject: "Your refill for #{@medication.name} is coming up soon!")
   end
 
+  def meeting_reminder(meeting: , member: )
+    @meeting = meeting
+    @member = member
+
+    mail(to: @member.email,
+         subject: "Your meeting \"#{@meeting.name}\" is tomorrow at #{@meeting.time}!")
+  end
+
   def notification_email(recipientid, data)
     @data = JSON.parse(data)
     @recipient = User.where(id: recipientid).first

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,7 +1,7 @@
 class NotificationMailer < ApplicationMailer
-   default from: ENV["DEFAULT_FROM_ADDRESS"]
+  default from: ENV['DEFAULT_FROM_ADDRESS']
 
-   ALLY_NOTIFY_TYPES = ["new_ally_request", "accepted_ally_request"]
+  ALLY_NOTIFY_TYPES = %w(new_ally_request accepted_ally_request).freeze
 
   def take_medication(reminder)
     @medication = reminder.medication
@@ -17,12 +17,17 @@ class NotificationMailer < ApplicationMailer
          subject: "Your refill for #{@medication.name} is coming up soon!")
   end
 
-  def meeting_reminder(meeting: , member: )
+  def meeting_reminder(meeting, member)
     @meeting = meeting
     @member = member
 
-    mail(to: @member.email,
-         subject: "Your meeting \"#{@meeting.name}\" is tomorrow at #{@meeting.time}!")
+    subject = I18n.t(
+      'meetings.reminder_mailer.subject',
+      meeting_name: @meeting.name,
+      time: @meeting.time
+    )
+
+    mail(to: @member.email, subject: subject)
   end
 
   def notification_email(recipientid, data)

--- a/app/services/meeting_reminders.rb
+++ b/app/services/meeting_reminders.rb
@@ -1,0 +1,17 @@
+class MeetingReminders
+
+  def send_meeting_reminder_emails
+    meetings_tomorrow.each do |meeting|
+      meeting.members.each do |member|
+        NotificationMailer.meeting_reminder(meeting: meeting, member: member).deliver_now
+      end
+    end
+  end
+
+  private
+
+  def meetings_tomorrow
+    tomorrow_as_string = 1.day.from_now.strftime('%m/%d/%Y')
+    Meeting.where(date: tomorrow_as_string)
+  end
+end

--- a/app/services/meeting_reminders.rb
+++ b/app/services/meeting_reminders.rb
@@ -1,9 +1,11 @@
-class MeetingReminders
+# frozen_string_literal: true
 
+# Public: Used for sending reminders regarding upcoming meetings
+class MeetingReminders
   def send_meeting_reminder_emails
     meetings_tomorrow.each do |meeting|
       meeting.members.each do |member|
-        NotificationMailer.meeting_reminder(meeting: meeting, member: member).deliver_now
+        NotificationMailer.meeting_reminder(meeting, member).deliver_now
       end
     end
   end

--- a/app/views/notification_mailer/meeting_reminder.html.erb
+++ b/app/views/notification_mailer/meeting_reminder.html.erb
@@ -1,7 +1,6 @@
 <p>
-  Hi <%= @member.name %>,
+  <%= t('meetings.reminder_mailer.salutation', name: @member.name) %>
 </p>
 <p>
-Here's a friendly reminder that your meeting tomorrow, "<%= @meeting.name%>", will be taking place at <%= @meeting.time %> at 
-<%= @meeting.location %>!
+  <%= t('meetings.reminder_mailer.body', meeting_name: @meeting.name, time: @meeting.time, location: @meeting.location) %>
 </p>

--- a/app/views/notification_mailer/meeting_reminder.html.erb
+++ b/app/views/notification_mailer/meeting_reminder.html.erb
@@ -1,0 +1,7 @@
+<p>
+  Hi <%= @member.name %>,
+</p>
+<p>
+Here's a friendly reminder that your meeting tomorrow, "<%= @meeting.name%>", will be taking place at <%= @meeting.time %> at 
+<%= @meeting.location %>!
+</p>

--- a/app/views/notification_mailer/meeting_reminder.text.erb
+++ b/app/views/notification_mailer/meeting_reminder.text.erb
@@ -1,4 +1,3 @@
-Hi <%= @member.name %>,
+<%= t('meetings.reminder_mailer.salutation', name: @member.name) %>
 
-Here's a friendly reminder that your meeting tomorrow, "<%= @meeting.name%>", will be taking place at <%= @meeting.time %> at 
-<%= @meeting.location %>!
+<%= t('meetings.reminder_mailer.body', meeting_name: @meeting.name, time: @meeting.time, location: @meeting.location) %>

--- a/app/views/notification_mailer/meeting_reminder.text.erb
+++ b/app/views/notification_mailer/meeting_reminder.text.erb
@@ -1,0 +1,4 @@
+Hi <%= @member.name %>,
+
+Here's a friendly reminder that your meeting tomorrow, "<%= @meeting.name%>", will be taking place at <%= @meeting.time %> at 
+<%= @meeting.location %>!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,6 +233,10 @@ en:
    members_of_group_html:
     one: '%{count} Member <strong>of</strong> %{group}'
     other: '%{count} Members <strong>of</strong> %{group}'
+  reminder_mailer:
+    subject: "Your meeting \"%{meeting_name}\" is tomorrow at %{time}!"
+    salutation: "Hi %{name},"
+    body: "Here's a friendly reminder that your meeting tomorrow, \"%{meeting_name}\", will be taking place at %{time} at %{location}!"
   leave:
     error: 'You cannot leave the meeting, you are the only leader.'
     success: 'You have left %{meeting}'

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -8,4 +8,9 @@ namespace :scheduler do
   task send_refill_reminders: :environment do
     MedicationReminders.new.send_refill_reminder_emails
   end
+
+  desc 'Send meeting reminders'
+  task send_meeting_reminders: :environment do
+    MeetingReminders.new.send_meeting_reminder_emails
+  end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -19,6 +19,16 @@ describe "NotificationMailer" do
     it { expect(email.subject).to eq("Your refill for Fancy Medication Name is coming up soon!") }
   end
 
+  describe '#meeting_reminder' do
+    let(:member) { FactoryGirl.create(:meeting_member, meeting: meeting).user }
+    let(:meeting) { FactoryGirl.create(:meeting) }
+
+    subject(:email) { NotificationMailer.meeting_reminder(meeting: meeting, member: member) }
+
+    it { expect(email.to).to eq([member.email]) }
+    it { expect(email.subject).to eq("Your meeting \"#{meeting.name}\" is tomorrow at #{meeting.time}!") }
+  end
+
   describe 'notification' do
     let(:who_triggered_event) { FactoryGirl.create(:user2) }
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -23,10 +23,45 @@ describe "NotificationMailer" do
     let(:member) { FactoryGirl.create(:meeting_member, meeting: meeting).user }
     let(:meeting) { FactoryGirl.create(:meeting) }
 
-    subject(:email) { NotificationMailer.meeting_reminder(meeting: meeting, member: member) }
+    subject(:email) { NotificationMailer.meeting_reminder(meeting, member) }
 
-    it { expect(email.to).to eq([member.email]) }
-    it { expect(email.subject).to eq("Your meeting \"#{meeting.name}\" is tomorrow at #{meeting.time}!") }
+    it 'sends the email to the correct recipient' do
+      expect(email.to).to eq([member.email])
+    end
+
+    it 'has the correct subject' do
+      expected_subject = I18n.t(
+        'meetings.reminder_mailer.subject',
+        meeting_name: meeting.name,
+        time: meeting.time
+      )
+
+      expect(email.subject).to eq(expected_subject)
+    end
+
+    it 'is addressed to the correct person' do
+      email.parts.each do |part|
+        expect(part.body.raw_source).to include(member.name)
+      end
+    end
+
+    it 'includes the meeting location' do
+      email.parts.each do |part|
+        expect(part.body.raw_source).to include(meeting.location)
+      end
+    end
+
+    it 'includes the meeting time' do
+      email.parts.each do |part|
+        expect(part.body.raw_source).to include(meeting.time)
+      end
+    end
+
+    it 'includes the meeting name' do
+      email.parts.each do |part|
+        expect(part.body.raw_source).to include(meeting.name)
+      end
+    end
   end
 
   describe 'notification' do

--- a/spec/services/meeting_reminders_spec.rb
+++ b/spec/services/meeting_reminders_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe MeetingReminders do
+  subject { described_class.new }
+
+  describe '#send_meeting_reminder_emails' do
+    let(:mail) { instance_double(ActionMailer::MessageDelivery) }
+    let!(:member_one) { FactoryGirl.create(:meeting_member, meeting: meeting) }
+    let!(:member_two) { FactoryGirl.create(:meeting_member, meeting: meeting) }
+    let(:meeting) do 
+      FactoryGirl.create(
+        :meeting,
+        maxmembers: 0,
+        date: date
+      )
+    end
+
+    before do
+      allow(NotificationMailer).to receive(:meeting_reminder).and_return(mail)
+    end
+
+    context 'when there are no meetings occurring tomorrow' do
+      let(:date) { 2.days.from_now.strftime('%m/%d/%Y') }
+
+      before do
+        subject.send_meeting_reminder_emails
+      end
+
+      it 'does not send any notification emails' do
+        expect(NotificationMailer).to_not have_received(:meeting_reminder)
+      end
+    end
+
+    context 'when there is a meeting occurring tomorrow' do
+      let(:date) { 1.days.from_now.strftime('%m/%d/%Y') }
+
+      before do
+        expect(mail).to receive(:deliver_now).twice
+        subject.send_meeting_reminder_emails
+      end
+
+      it 'sends a notification email to each member' do
+        expect(NotificationMailer)
+          .to have_received(:meeting_reminder)
+          .with(meeting: meeting, member: member_one.user)
+        expect(NotificationMailer)
+          .to have_received(:meeting_reminder)
+          .with(meeting: meeting, member: member_two.user)
+      end
+    end
+  end
+end

--- a/spec/services/meeting_reminders_spec.rb
+++ b/spec/services/meeting_reminders_spec.rb
@@ -7,7 +7,7 @@ describe MeetingReminders do
     let(:mail) { instance_double(ActionMailer::MessageDelivery) }
     let!(:member_one) { FactoryGirl.create(:meeting_member, meeting: meeting) }
     let!(:member_two) { FactoryGirl.create(:meeting_member, meeting: meeting) }
-    let(:meeting) do 
+    let(:meeting) do
       FactoryGirl.create(
         :meeting,
         maxmembers: 0,
@@ -35,17 +35,20 @@ describe MeetingReminders do
       let(:date) { 1.days.from_now.strftime('%m/%d/%Y') }
 
       before do
-        expect(mail).to receive(:deliver_now).twice
+        allow(mail).to receive(:deliver_now)
         subject.send_meeting_reminder_emails
       end
 
       it 'sends a notification email to each member' do
         expect(NotificationMailer)
           .to have_received(:meeting_reminder)
-          .with(meeting: meeting, member: member_one.user)
+          .with(meeting, member_one.user)
+
         expect(NotificationMailer)
           .to have_received(:meeting_reminder)
-          .with(meeting: meeting, member: member_two.user)
+          .with(meeting, member_two.user)
+
+        expect(mail).to have_received(:deliver_now).twice
       end
     end
   end


### PR DESCRIPTION
This adds a send_meeting_reminders task to the scheduler to send an email reminder to all meeting members a day before the meeting occurs (see issue #131).

**Notes:**
Since the `Meeting` models use strings for their `date` and `time` fields it makes it a bit difficult to query.  We should probably have an enhancement later to migrate them over to using a time field.

Given that, the way this is coded if you configure the scheduler on Heroku to run the `send_meeting_reminders` task daily at some time (midnight?) it will send an email to everyone who is attending a meeting the following day 24 hours+ in advance.

If you would like for the emails to be sent closer to 24 hours in advance in regards to the meeting's `time` field it gets a bit trickier since it's a string column and time zones become a bigger factor.

Regardless, I think this code is a decent MVP and can be expanded upon later if desired.  :)

Let me know what you would like changed and please give suggestions for improvement. 👍 

Thanks,
Tim