### PR TITLE
Use DELETE instead of GET for Notifications#clear [#320]

### DIFF
--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -239,9 +239,12 @@ var onReadyNotifications = function() {
     showNotificationsNone();
     changeTitle(0);
 
-    $.ajax("/notifications/clear");
-    $('#notifications #clear_notifcations').hide();
+    $.ajax({
+      url: '/notifications/clear',
+      type: 'DELETE'
+    });
 
+    $('#notifications #clear_notifcations').hide();
   });
 
   /* Quick Moment */

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,7 @@ Rails.application.routes.draw do
 
   resources :notifications, :except => [:show, :new, :create, :edit, :update] do
     collection do
-      get "clear"
+      delete 'clear'
       get "fetch_notifications"
       get "signed_in"
     end

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,3 +1,76 @@
-describe NotificationsController do
+RSpec.describe NotificationsController, type: :controller do
+  describe '#clear' do
+    let(:user) { FactoryGirl.create(:user1) }
+    let(:other_user) { FactoryGirl.create(:user2) }
+    let!(:other_user_notification) do
+      FactoryGirl.create(:notification, user: other_user)
+    end
 
+    context 'when the user is signed in' do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      context 'when the user has notifications' do
+        let!(:notification) do
+          FactoryGirl.create(:notification, user: user)
+        end
+
+        let!(:notification_two) do
+          FactoryGirl.create(:notification, user: user)
+        end
+
+        it 'deletes all notifications belonging to the current user' do
+          expect(Notification.where(userid: user.id).count).to eq(2)
+
+          delete :clear
+          expect(Notification.where(userid: user.id).count).to eq(0)
+        end
+
+        it 'does not delete notifications belonging to other users' do
+          expect(Notification.where(userid: other_user.id).count).to eq(1)
+
+          delete :clear
+          expect(Notification.where(userid: other_user.id).count).to eq(1)
+        end
+      end
+
+      context 'when the user does not have notifications' do
+        it 'does does not delete any notifications' do
+          delete :clear
+          expect(Notification.where(userid: user.id)).to be_empty
+        end
+      end
+
+      it 'renders nothing' do
+        delete :clear
+        expect(response).to have_http_status 200
+        expect(response.body).to be_empty
+      end
+    end
+
+    context 'when the user is not signed in' do
+      before do
+        allow(controller).to receive(:user_signed_in?).and_return(false)
+
+        delete :clear, format: format
+      end
+
+      context 'and the requested format is html' do
+        let(:format) { 'html' }
+
+        it 'redirects to the new_user_session_path' do
+          expect(response).to redirect_to new_user_session_path
+        end
+      end
+
+      context 'and the requested format is json' do
+        let(:format) { 'json' }
+
+        it 'renders a HEAD response with :no_content' do
+          expect(response).to have_http_status 204
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Copied this from issue #320 for context:
> Notifications for a user can currently be cleared by visiting the following route:
> ```
clear_notifications GET      /notifications/clear(.:format)               notifications#clear
```

> Since the action is destroying all of a user's notifications, it should be an HTTP `DELETE` request instead of a `GET` since it is neither safe nor idempotent. ([reference](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html))

> Moving away from `GET` also has the added benefit of letting us use Rail's CSRF security token in these requests. 🎃  🌝 
