### PR TITLE
Add Docker Compose configuration files

### DIFF
--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -1,7 +1,7 @@
 development: &default
   adapter: postgresql
   encoding: unicode
-  host: localhost
+  host: <%= ENV['PSQL_HOST'] || 'localhost' %>
   database: ifme_development
   allow_concurrency: true
   pool: 5

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  app:
+    depends_on:
+      - selenium
+    environment:
+      - SELENIUM_REMOTE_HOST=selenium
+  selenium:
+    image: selenium/standalone-firefox
+    container_name: selenium

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  psql:
+    image: postgres:9.6
+    environment:
+      - POSTGRES_PASSWORD=
+      - POSTGRES_USER=root
+  app:
+    build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - psql
+    environment:
+      - PSQL_HOST=psql


### PR DESCRIPTION
Having Docker and Docker Compose installed, a user is now able to start the server using

```
$ docker-compose up
```

or open a shell using

```
$ docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm app bash
```

, wherein now also tests will pass, that depend on Selenium and Firefox (also see #317).