### PR TITLE
Responsive work on new medication form

### DIFF
--- a/app/assets/stylesheets/application/medications.scss
+++ b/app/assets/stylesheets/application/medications.scss
@@ -50,4 +50,10 @@
 	#medication_content {
 		padding: 0;
 	}
+
+	label[for="refill_reminder"],
+	label[for="take_medication_reminder"],
+	label[for="medication_Google Calendar reminder"] {
+		font-size: 20px;
+	}
 }

--- a/app/views/medications/_form.html.erb
+++ b/app/views/medications/_form.html.erb
@@ -10,7 +10,7 @@
 
     <div class="table_cell padding_right vertical_align_top">
 
-      <div class="field" >
+      <div class="field">
         <div class="label">
           <%= f.label t('medications.form.name'), for: 'medication_name' %>
           <i class="fa fa-asterisk align_right"></i>


### PR DESCRIPTION
Julia informed me that on mobile, the form was stretching past the natural width of the screen, so this is an attempt on hopefully fixing that up. I used the Chrome emulator on the Galaxy S5, Nexus 6P, iPhones 4, 5, and 6(Plus), as well as a couple others. I also used the Responsive Web Design Tester plugin for Chrome (which includes the Galaxy S6 and S6 Edge). 

Her screenshots from before:

![screenshot_20161013-004231](https://cloud.githubusercontent.com/assets/13127241/19373895/30140820-918d-11e6-8a6a-1baddb7c91a3.png)
![screenshot_20161013-004247](https://cloud.githubusercontent.com/assets/13127241/19373896/30169946-918d-11e6-82e5-8d9de093d571.png)

And samples from the emulators after:

<img width="321" alt="screen shot 2016-10-13 at 8 47 37 pm" src="https://cloud.githubusercontent.com/assets/13127241/19373915/464d5b46-918d-11e6-9a89-c2b3cd1a4953.png">
<img width="313" alt="screen shot 2016-10-13 at 8 47 54 pm" src="https://cloud.githubusercontent.com/assets/13127241/19373924/5948264a-918d-11e6-9b0a-7bfd51c3169f.png">

<img width="360" alt="screen shot 2016-10-13 at 9 38 58 pm" src="https://cloud.githubusercontent.com/assets/13127241/19373946/88fca08c-918d-11e6-9ab1-363e23d4b6b7.png">
<img width="359" alt="screen shot 2016-10-13 at 9 39 12 pm" src="https://cloud.githubusercontent.com/assets/13127241/19373947/89001b36-918d-11e6-87b8-801fb2a6d431.png">

Looking back on it now, it appears it was being stretched due to the Reminder checkbox text being too large on the original. I dropped the font size on smaller screens to hopefully fix this issue. 🙂