### PR TITLE
Fixes #411

### DIFF
--- a/config/cloudinary.yml
+++ b/config/cloudinary.yml
@@ -16,3 +16,4 @@ production:
   api_secret: ENV["CLOUDINARY_API_SECRET"]
   enhance_image_tag: true
   static_image_support: false
+  secure: true


### PR DESCRIPTION
Add the `secure: true` property in cloudinary.yml to force the loading over HTTPS