### PR TITLE
Update readme with more postgres instructions

### DIFF
--- a/Errors.md
+++ b/Errors.md
@@ -95,6 +95,19 @@ development: &default
   password: <%= ENV["PSQL_PASSWORD"] %>
 ```
 
+#### PostgreSQL 9.6.1 ERROR: 
+```
+FATAL:  database files are incompatible with server
+DETAIL:  The data directory was initialized by PostgreSQL version 9.4, which is not compatible with this version 9.6.1.
+```
+
+... you can do the following: 
+1) `brew install postgresql@9.4`
+2) `brew services start postgresql@9.4`
+
+And to stop the server:
+`brew services stop postgresql@9.4`
+
 ## Testing rpec
 #### ERROR: `FATAL:  database "ifme_test" does not exist`
 TO FIX:

--- a/README.md
+++ b/README.md
@@ -140,19 +140,6 @@ then start the postgres server:
 
 `postgres -D /usr/local/var/postgres`
 
-If you're getting the following error: 
-```
-FATAL:  database files are incompatible with server
-DETAIL:  The data directory was initialized by PostgreSQL version 9.4, which is not compatible with this version 9.6.1.
-```
-
-... you can do the following: 
-1) `brew install postgresql@9.4`
-2) `brew services start postgresql@9.4`
-
-And to stop the server:
-`brew services stop postgresql@9.4`
-
 For more information, follow [this postgresql guide](http://exponential.io/blog/2015/02/21/install-postgresql-on-mac-os-x-via-brew/) for a more detailed setup
 
 #### B. Linux

--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ then start the postgres server:
 
 `postgres -D /usr/local/var/postgres`
 
+If you're getting the following error: 
+```
+FATAL:  database files are incompatible with server
+DETAIL:  The data directory was initialized by PostgreSQL version 9.4, which is not compatible with this version 9.6.1.
+```
+
+... you can do the following: 
+1) `brew install postgresql@9.4`
+2) `brew services start postgresql@9.4`
+
+And to stop the server:
+`brew services stop postgresql@9.4`
+
 For more information, follow [this postgresql guide](http://exponential.io/blog/2015/02/21/install-postgresql-on-mac-os-x-via-brew/) for a more detailed setup
 
 ### Linux


### PR DESCRIPTION
Add instructions for postgres error*, and instructions re: how to stop and start postgres server with brew.


```
FATAL:  database files are incompatible with server
DETAIL:  The data directory was initialized by PostgreSQL version 9.4, which is not compatible with this version 9.6.1.
```