### PR TITLE
Use slugs in stat links

### DIFF
--- a/app/helpers/viewers_helper.rb
+++ b/app/helpers/viewers_helper.rb
@@ -15,6 +15,7 @@ module ViewersHelper
       item = ob.send(data_type)
       return ob.viewers if item.include?(data.id)
     end
+    []
   end
 
   def number_of_viewers(current_user_id, strategy_owner_id, viewers)
@@ -30,7 +31,7 @@ module ViewersHelper
 
   private def add_link(link, result)
     content_tag(:span, result) do
-      link_to link.name, "/#{link.model_name.plural}/#{link.id}"
+      link_to link.name, link.model_name.to_s.classify.constantize.find(link.id)
     end
   end
 

--- a/spec/helpers/viewers_helper_spec.rb
+++ b/spec/helpers/viewers_helper_spec.rb
@@ -78,7 +78,7 @@ describe ViewersHelper do
       new_category = create(:category, userid: new_user1.id)
       new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category.id))
       result = viewers_hover(nil, new_category)
-      expect(result).to eq('<span class="yes_title" title="Visible to only you"><a href="/categories/' + new_category.id.to_s + '">Test Category</a></span>')
+      expect(result).to eq('<span class="yes_title" title="Visible to only you"><a href="/categories/test-category">Test Category</a></span>')
     end
 
     it "displays list of viewers without link" do
@@ -97,7 +97,7 @@ describe ViewersHelper do
       new_category = create(:category, userid: new_user1.id)
       new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category.id), viewers: viewers)
       result = viewers_hover(viewers, new_category)
-      expect(result).to eq('<span class="yes_title" title="Visible to Oprah Chang, Plum Blossom, and Gentle Breezy"><a href="/categories/' + new_category.id.to_s + '">Test Category</a></span>')
+      expect(result).to eq('<span class="yes_title" title="Visible to Oprah Chang, Plum Blossom, and Gentle Breezy"><a href="/categories/test-category">Test Category</a></span>')
     end
   end
 


### PR DESCRIPTION
* get_viewers should return empty array if no viewers found
* Use slugs instead of ids for links generated by profile stats