### PR TITLE
Corrects google calendar reminder bug, fixes #505

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -90,11 +90,11 @@ class MedicationsController < ApplicationController
 
   # Save refill date to Google calendar
   def save_refill_to_google_calendar(medication)
-    return unless current_user.google_oauth2_enabled? && medication.add_to_google_cal
-
-    summary = 'Refill for ' + medication.name
-    date = medication.refill
-    CalendarUploader.new(summary: summary, date: date, access_token: current_user.token, email: current_user.email).upload_event
+    if current_user.google_oauth2_enabled? && medication.add_to_google_cal == "1"
+      summary = 'Refill for ' + medication.name
+      date = medication.refill
+      CalendarUploader.new(summary: summary, date: date, access_token: current_user.token, email: current_user.email).upload_event
+    end
   end
 
   private

--- a/spec/features/adding_medication_spec.rb
+++ b/spec/features/adding_medication_spec.rb
@@ -13,6 +13,7 @@ describe "user adds a new medication" do
     fill_in "Dosage", with: 2
     fill_in "Refill", with: "05/25/2016"
     CalendarUploader.stub_chain(:new, :upload_event)
+    expect(CalendarUploader).to_not receive(:new)
     click_on "Submit"
     expect(page).to have_content("A medication name")
     new_medication = user.medications.last
@@ -32,6 +33,7 @@ describe "user adds a new medication" do
       find(:css, "#take_medication_reminder").set(true)
       find(:css, "#refill_reminder").set(true)
       CalendarUploader.stub_chain(:new, :upload_event)
+      expect(CalendarUploader).to_not receive(:new)
       click_on "Submit"
       expect(page).to have_content("A medication name")
       new_medication = user.medications.last
@@ -51,6 +53,7 @@ describe "user adds a new medication" do
     find(:css, "#refill_reminder").set(true)
     find(:css, "#medication_add_to_google_cal").set(true)
     CalendarUploader.stub_chain(:new, :upload_event)
+    expect(CalendarUploader).to receive_message_chain(:new)
     click_on "Submit"
     expect(page).to have_content("A medication name")
     new_medication = user.medications.last


### PR DESCRIPTION
Google calendar reminders are only added if explicitly requested by user, where before reminders were added every time.