### PR TITLE
Auth key lifespan

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -93,21 +93,24 @@ class MedicationsController < ApplicationController
                        medication.add_to_google_cal == '1'
 
     summary = 'Refill for ' + medication.name
-    date = medication.refill
     begin
       CalendarUploader.new(summary: summary,
-                           date: date,
+                           date: medication.refill,
                            access_token: current_user.access_token,
                            email: current_user.email).upload_event
     rescue
-      sign_out current_user
-      respond_to do |format|
-        format.html { redirect_to new_user_session_path }
-        format.json { head :no_content }
-      end
+      return_to_sign_in
       false
     else
       true
+    end
+  end
+
+  def return_to_sign_in
+    sign_out current_user
+    respond_to do |format|
+      format.html { redirect_to new_user_session_path }
+      format.json { head :no_content }
     end
   end
 

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -51,37 +51,36 @@ class MedicationsController < ApplicationController
   # POST /medications.json
   def create
     @medication = Medication.new(medication_params)
+    return unless save_refill_to_google_calendar(@medication)
 
-    if save_refill_to_google_calendar(@medication)
-      if @medication.save
-        respond_to do |format|
-          format.html { redirect_to medication_path(@medication) }
-          format.json { render :show, status: :ok, location: @medication }
-        end
-      else
-        respond_to do |format|
-          format.html { render :new }
-          format.json { render json: @medication.errors, status: :unprocessable_entity }
-        end
+    if @medication.save
+      respond_to do |format|
+        format.html { redirect_to medication_path(@medication) }
+        format.json { render :show, status: :ok, location: @medication }
+      end
+    else
+      respond_to do |format|
+        format.html { render :new }
+        format.json { render json: @medication.errors,
+                             status: :unprocessable_entity }
       end
     end
-
   end
 
   # PATCH/PUT /medications/1
   # PATCH/PUT /medications/1.json
   def update
-    if save_refill_to_google_calendar(@medication)
-      if @medication.update(medication_params)
-        respond_to do |format|
-          format.html { redirect_to medication_path(@medication) }
-          format.json { render :show, status: :ok, location: @medication }
-        end
-      else
-        respond_to do |format|
-          format.html { render :new }
-          format.json { render json: @medication.errors, status: :unprocessable_entity }
-        end
+    return unless save_refill_to_google_calendar(@medication)
+    if @medication.update(medication_params)
+      respond_to do |format|
+        format.html { redirect_to medication_path(@medication) }
+        format.json { render :show, status: :ok, location: @medication }
+      end
+    else
+      respond_to do |format|
+        format.html { render :new }
+        format.json { render json: @medication.errors,
+                              status: :unprocessable_entity }
       end
     end
   end
@@ -99,7 +98,7 @@ class MedicationsController < ApplicationController
   # Save refill date to Google calendar
   def save_refill_to_google_calendar(medication)
     return true unless current_user.google_oauth2_enabled? &&
-      medication.add_to_google_cal == '1'
+                       medication.add_to_google_cal == '1'
 
     summary = 'Refill for ' + medication.name
     date = medication.refill
@@ -114,7 +113,7 @@ class MedicationsController < ApplicationController
         format.html { redirect_to new_user_session_path }
         format.json { head :no_content }
       end
-      false 
+      false
     else
       true
     end

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -59,11 +59,7 @@ class MedicationsController < ApplicationController
         format.json { render :show, status: :ok, location: @medication }
       end
     else
-      respond_to do |format|
-        format.html { render :new }
-        format.json { render json: @medication.errors,
-                             status: :unprocessable_entity }
-      end
+      render_unprocessable_medication
     end
   end
 
@@ -77,11 +73,7 @@ class MedicationsController < ApplicationController
         format.json { render :show, status: :ok, location: @medication }
       end
     else
-      respond_to do |format|
-        format.html { render :new }
-        format.json { render json: @medication.errors,
-                              status: :unprocessable_entity }
-      end
+      render_unprocessable_medication
     end
   end
 
@@ -120,6 +112,16 @@ class MedicationsController < ApplicationController
   end
 
   private
+
+  def render_unprocessable_medication
+    respond_to do |format|
+      format.html { render :new }
+      format.json do
+        render(json: @medication.errors,
+               status: :unprocessable_entity)
+      end
+    end
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_medication

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -94,7 +94,7 @@ class MedicationsController < ApplicationController
 
     summary = 'Refill for ' + medication.name
     date = medication.refill
-    CalendarUploader.new(summary: summary, date: date, access_token: current_user.token, email: current_user.email).upload_event
+    CalendarUploader.new(summary: summary, date: date, access_token: current_user.access_token, email: current_user.email).upload_event
   end
 
   private

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -54,7 +54,7 @@ class MedicationsController < ApplicationController
     if @medication.valid?
       save_refill_to_google_calendar(@medication)
     else
-    repond_to do |format|
+      repond_to do |format|
         format.html { render :new }
         format.json { render json: @medication.errors, status: :unprocessable_entity }
       end
@@ -93,9 +93,9 @@ class MedicationsController < ApplicationController
     date = medication.refill
     begin
       CalendarUploader.new(summary: summary,
-                          date: date,
-                          access_token: current_user.access_token,
-                          email: current_user.email).upload_event
+                           date: date,
+                           access_token: current_user.access_token,
+                           email: current_user.email).upload_event
     rescue
       sign_out current_user
       respond_to do |format|

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -54,10 +54,7 @@ class MedicationsController < ApplicationController
     return unless save_refill_to_google_calendar(@medication)
 
     if @medication.save
-      respond_to do |format|
-        format.html { redirect_to medication_path(@medication) }
-        format.json { render :show, status: :ok, location: @medication }
-      end
+      redirect_to_medication(@medication)
     else
       render_unprocessable_medication
     end
@@ -68,10 +65,7 @@ class MedicationsController < ApplicationController
   def update
     return unless save_refill_to_google_calendar(@medication)
     if @medication.update(medication_params)
-      respond_to do |format|
-        format.html { redirect_to medication_path(@medication) }
-        format.json { render :show, status: :ok, location: @medication }
-      end
+      redirect_to_medication(@medication)
     else
       render_unprocessable_medication
     end
@@ -123,6 +117,13 @@ class MedicationsController < ApplicationController
         render(json: @medication.errors,
                status: :unprocessable_entity)
       end
+    end
+  end
+
+  def redirect_to_medication(medication)
+    respond_to do |format|
+      format.html { redirect_to medication_path(medication) }
+      format.json { render :show, status: :ok, location: medication }
     end
   end
 

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -5,7 +5,7 @@ require 'google/api_client'
 class MedicationsController < ApplicationController
   include CollectionPageSetup
   include ReminderHelper
-  helper_method :save_refill_to_google_calendar
+  include MedicationRefillHelper
   before_action :set_medication, only: %i[show edit update destroy]
 
   # GET /medications
@@ -81,31 +81,13 @@ class MedicationsController < ApplicationController
     end
   end
 
-  # Save refill date to Google calendar
-  def save_refill_to_google_calendar(medication)
-    return true unless current_user.google_oauth2_enabled? &&
-                       medication.add_to_google_cal == '1'
-
-    summary = 'Refill for ' + medication.name
-    begin
-      CalendarUploader.new(summary: summary,
-                           date: medication.refill,
-                           access_token: current_user.access_token,
-                           email: current_user.email).upload_event
-    rescue
-      return_to_sign_in
-      false
-    else
-      true
-    end
-  end
-
   def return_to_sign_in
     sign_out current_user
     respond_to do |format|
       format.html { redirect_to new_user_session_path }
       format.json { head :no_content }
     end
+    false
   end
 
   private

--- a/app/helpers/medication_refill_helper.rb
+++ b/app/helpers/medication_refill_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module MedicationRefillHelper
+  # Save refill date to Google calendar
+  def save_refill_to_google_calendar(medication)
+    return true unless current_user.google_oauth2_enabled? &&
+                       medication.add_to_google_cal == '1'
+    begin
+      args = calendar_uploader_params(medication)
+      CalendarUploader.new(args).upload_event
+    rescue
+      return_to_sign_in
+    else
+      true
+    end
+  end
+
+  def calendar_uploader_params(medication)
+    { summary: "Refill for #{medication.name}",
+      date: medication.refill,
+      access_token: current_user.access_token,
+      email: current_user.email }
+  end
+end

--- a/app/helpers/medication_refill_helper.rb
+++ b/app/helpers/medication_refill_helper.rb
@@ -18,7 +18,7 @@ module MedicationRefillHelper
   def calendar_uploader_params(medication)
     { summary: "Refill for #{medication.name}",
       date: medication.refill,
-      access_token: current_user.access_token,
+      access_token: current_user.google_access_token,
       email: current_user.email }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: users
@@ -39,6 +38,7 @@
 #  group_notify           :boolean
 #  meeting_notify         :boolean
 #  locale                 :string
+#  access_expires_at      :datetime
 #
 
 class User < ActiveRecord::Base
@@ -87,7 +87,8 @@ class User < ActiveRecord::Base
     user.update!(
       provider: access_token.provider,
       token: access_token.credentials.token,
-      uid: access_token.uid
+      uid: access_token.uid,
+      access_expires_at: Time.at(access_token.credentials.expires_at)
     )
     user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,7 @@
 #  meeting_notify         :boolean
 #  locale                 :string
 #  access_expires_at      :datetime
+#  refresh_token          :string
 #
 
 class User < ActiveRecord::Base
@@ -87,6 +88,7 @@ class User < ActiveRecord::Base
     user.update!(
       provider: access_token.provider,
       token: access_token.credentials.token,
+      refresh_token: access_token.credentials.refresh_token,
       uid: access_token.uid,
       access_expires_at: Time.at(access_token.credentials.expires_at)
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ActiveRecord::Base
     user
   end
 
-  def access_token
+  def google_access_token
     if !access_expires_at || Time.zone.now > access_expires_at
       update_access_token
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ActiveRecord::Base
   end
 
   def access_token
-    if Time.zone.now > access_expires_at
+    if !access_expires_at || Time.zone.now > access_expires_at
       update_access_token
     else
       token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < ActiveRecord::Base
       token: access_token.credentials.token,
       refresh_token: access_token.credentials.refresh_token,
       uid: access_token.uid,
-      access_expires_at: Time.at(access_token.credentials.expires_at)
+      access_expires_at: Time.zone.at(access_token.credentials.expires_at)
     )
     user
   end
@@ -104,20 +104,20 @@ class User < ActiveRecord::Base
   end
 
   def update_access_token
-    url = URI("https://accounts.google.com/o/oauth2/token")
+    url = URI('https://accounts.google.com/o/oauth2/token')
     refresh_token_params = { 'refresh_token' => refresh_token,
-                              'client_id'     => nil,
-                              'client_secret' => nil,
-                              'grant_type'    => 'refresh_token' }
+                             'client_id'     => nil,
+                             'client_secret' => nil,
+                             'grant_type'    => 'refresh_token' }
 
     time_of_request = Time.zone.now
     response = Net::HTTP.post_form(url, refresh_token_params)
     decoded_response = JSON.parse(response.body)
 
-    new_expiration_time =  time_of_request + decoded_response["expires_in"]
-    new_access_token = decoded_response["access_token"]
+    new_expiration_time = time_of_request + decoded_response['expires_in']
+    new_access_token = decoded_response['access_token']
 
-    self.update(
+    update(
       token: new_access_token,
       access_expires_at: new_expiration_time
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,12 +106,11 @@ class User < ActiveRecord::Base
   def update_access_token
     url = URI("https://accounts.google.com/o/oauth2/token")
     refresh_token_params = { 'refresh_token' => refresh_token,
-                              'client_id'     => ENV['GOOGLE_CLIENT_ID'],
-                              'client_secret' => ENV['GOOGLE_CLIENT_SECRET'],
+                              'client_id'     => nil,
+                              'client_secret' => nil,
                               'grant_type'    => 'refresh_token' }
 
     time_of_request = Time.zone.now
-    # TODO handle a failed request
     response = Net::HTTP.post_form(url, refresh_token_params)
     decoded_response = JSON.parse(response.body)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,7 +118,7 @@ class User < ActiveRecord::Base
     new_expiration_time =  time_of_request + decoded_response["expires_in"]
     new_access_token = decoded_response["access_token"]
 
-    self.update!(
+    self.update(
       token: new_access_token,
       access_expires_at: new_expiration_time
     )

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -309,6 +309,6 @@ Devise.setup do |config|
   require 'omniauth-google-oauth2'
     config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'],
     ENV['GOOGLE_CLIENT_SECRET'],
-    { access_type: "offline", approval_prompt: "",
-    scope: 'userinfo.email,calendar' }
+    { access_type: "offline", approval_prompt: "select_account consent force",
+    scope: 'userinfo.email,userinfo.profile,calendar' }
 end

--- a/db/migrate/20170724124951_add_access_expires_at_to_user.rb
+++ b/db/migrate/20170724124951_add_access_expires_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddAccessExpiresAtToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :access_expires_at, :datetime
+  end
+end

--- a/db/migrate/20170724160338_add_refresh_token_to_user.rb
+++ b/db/migrate/20170724160338_add_refresh_token_to_user.rb
@@ -1,0 +1,5 @@
+class AddRefreshTokenToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :refresh_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170225182017) do
+ActiveRecord::Schema.define(version: 20170724124951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -246,6 +246,7 @@ ActiveRecord::Schema.define(version: 20170225182017) do
     t.boolean  "group_notify"
     t.boolean  "meeting_notify"
     t.string   "locale"
+    t.datetime "access_expires_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170724124951) do
+ActiveRecord::Schema.define(version: 20170724160338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -247,6 +247,7 @@ ActiveRecord::Schema.define(version: 20170724124951) do
     t.boolean  "meeting_notify"
     t.string   "locale"
     t.datetime "access_expires_at"
+    t.string   "refresh_token"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -38,6 +38,7 @@
 #  meeting_notify         :boolean
 #  locale                 :string
 #  access_expires_at      :datetime
+#  refresh_token          :string
 #
 
 FactoryGirl.define do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -37,6 +37,7 @@
 #  group_notify           :boolean
 #  meeting_notify         :boolean
 #  locale                 :string
+#  access_expires_at      :datetime
 #
 
 FactoryGirl.define do

--- a/spec/features/adding_medication_spec.rb
+++ b/spec/features/adding_medication_spec.rb
@@ -53,7 +53,7 @@ describe "user adds a new medication" do
     find(:css, "#refill_reminder").set(true)
     find(:css, "#medication_add_to_google_cal").set(true)
     CalendarUploader.stub_chain(:new, :upload_event)
-    expect(CalendarUploader).to receive_message_chain(:new)
+    expect_any_instance_of(CalendarUploader).to receive(:new)
     click_on "Submit"
     expect(page).to have_content("A medication name")
     new_medication = user.medications.last
@@ -69,16 +69,14 @@ describe "user adds a new medication" do
       fill_in "Total", with: 30
       fill_in "Dosage", with: 30
       fill_in "Refill", with: "05/25/2016"
-      find(:css, "#take_medication_reminder").set(true)
       find(:css, "#refill_reminder").set(true)
       find(:css, "#medication_add_to_google_cal").set(true)
-      allow(CalendarUploader).to receive(:new).and_raise("boom")
-      expect(CalendarUploader).to receive_message_chain(:new)
+      CalendarUploader.stub_chain(:new, :upload_event).and_raise(StandardError.new("error"))
       click_on "Submit"
-      expect(page).to have_content("Sign in with Google")
+      expect(page).to have_content("Email")
       new_medication = user.medications.last
-      expect(new_medication.take_medication_reminder.active?).to eq(true)
-      expect(new_medication.refill_reminder.active?).to eq(true)
+      expect(new_medication).to eq(nil)
+      
     end
   end
 end

--- a/spec/features/adding_medication_spec.rb
+++ b/spec/features/adding_medication_spec.rb
@@ -1,6 +1,8 @@
 describe "user adds a new medication" do
   let!(:user) { FactoryGirl.create(:user_oauth) }
   before do
+    user.token = "some token"
+    user.access_expires_at = Time.zone.now + 600
     login_as user
     visit new_medication_path
   end
@@ -53,7 +55,7 @@ describe "user adds a new medication" do
     find(:css, "#refill_reminder").set(true)
     find(:css, "#medication_add_to_google_cal").set(true)
     CalendarUploader.stub_chain(:new, :upload_event)
-    expect_any_instance_of(CalendarUploader).to receive(:new)
+    expect(CalendarUploader).to receive_message_chain(:new, :upload_event)
     click_on "Submit"
     expect(page).to have_content("A medication name")
     new_medication = user.medications.last

--- a/spec/features/adding_medication_spec.rb
+++ b/spec/features/adding_medication_spec.rb
@@ -60,4 +60,25 @@ describe "user adds a new medication" do
     expect(new_medication.take_medication_reminder.active?).to eq(true)
     expect(new_medication.refill_reminder.active?).to eq(true)
   end
+
+  context "when uploader raises an error" do
+    it "redirects to sign in" do
+      fill_in "Name", with: "A medication name"
+      fill_in "medication_comments", with: "A comment"
+      fill_in "Strength", with: 100
+      fill_in "Total", with: 30
+      fill_in "Dosage", with: 30
+      fill_in "Refill", with: "05/25/2016"
+      find(:css, "#take_medication_reminder").set(true)
+      find(:css, "#refill_reminder").set(true)
+      find(:css, "#medication_add_to_google_cal").set(true)
+      allow(CalendarUploader).to receive(:new).and_raise("boom")
+      expect(CalendarUploader).to receive_message_chain(:new)
+      click_on "Submit"
+      expect(page).to have_content("Sign in with Google")
+      new_medication = user.medications.last
+      expect(new_medication.take_medication_reminder.active?).to eq(true)
+      expect(new_medication.refill_reminder.active?).to eq(true)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,12 +42,13 @@
 
 describe User do
   describe ".find_for_google_oauth2" do
+    let(:current_time) { Time.zone.now }
     let(:access_token) {
       double({
                 info: double({ email: "some@user.com", name: "some name" }),
                 provider: "asdf",
                 credentials: double({ token: "some token",
-                                 expires_at: Time.zone.now.to_i }),
+                                 expires_at: current_time.to_i }),
                 uid: "some uid"
       })
     }
@@ -61,7 +62,7 @@ describe User do
         expect(user.provider).to eq("asdf")
         expect(user.token).to eq("some token")
         expect(user.uid).to eq("some uid")
-        expect(user.access_expires_at).to eq(Time.at(Time.zone.now.to_i))
+        expect(user.access_expires_at).to eq(Time.at(current_time.to_i))
       end
 
       it "returns a user" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -93,6 +93,18 @@ describe User do
                               password: "asdfasdf", 
                               token: "some token" )}
 
+    context "no expiration saved" do
+      it "updates the access token" do
+        User.stub(:update_access_token) {
+          "some new token"
+        }
+        user.access_expires_at = nil
+        
+        expect_any_instance_of(User).to receive(:update_access_token)
+        user.access_token
+      end
+    end
+
     context "an expired token" do
       before do
         user.access_expires_at = current_time - 600

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,6 +37,7 @@
 #  group_notify           :boolean
 #  meeting_notify         :boolean
 #  locale                 :string
+#  access_expires_at      :datetime
 #
 
 describe User do
@@ -45,7 +46,8 @@ describe User do
       double({
                 info: double({ email: "some@user.com", name: "some name" }),
                 provider: "asdf",
-                credentials: double({ token: "some token" }),
+                credentials: double({ token: "some token",
+                                 expires_at: Time.zone.now.to_i }),
                 uid: "some uid"
       })
     }
@@ -59,6 +61,7 @@ describe User do
         expect(user.provider).to eq("asdf")
         expect(user.token).to eq("some token")
         expect(user.uid).to eq("some uid")
+        expect(user.access_expires_at).to eq(Time.at(Time.zone.now.to_i))
       end
 
       it "returns a user" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,6 +38,7 @@
 #  meeting_notify         :boolean
 #  locale                 :string
 #  access_expires_at      :datetime
+#  refresh_token          :string
 #
 
 describe User do
@@ -48,7 +49,8 @@ describe User do
                 info: double({ email: "some@user.com", name: "some name" }),
                 provider: "asdf",
                 credentials: double({ token: "some token",
-                                 expires_at: current_time.to_i }),
+                                      expires_at: current_time.to_i,
+                                      refresh_token: "some refresh token"}),
                 uid: "some uid"
       })
     }
@@ -61,6 +63,7 @@ describe User do
         user.reload
         expect(user.provider).to eq("asdf")
         expect(user.token).to eq("some token")
+        expect(user.refresh_token).to eq("some refresh token")
         expect(user.uid).to eq("some uid")
         expect(user.access_expires_at).to eq(Time.at(current_time.to_i))
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,7 +43,7 @@
 
 describe User do
   let(:current_time) { Time.zone.now }
-  
+
   describe ".find_for_google_oauth2" do
     let(:access_token) {
       double({
@@ -99,9 +99,9 @@ describe User do
           "some new token"
         }
         user.access_expires_at = nil
-        
+
         expect_any_instance_of(User).to receive(:update_access_token)
-        user.access_token
+        user.google_access_token
       end
     end
 
@@ -115,7 +115,7 @@ describe User do
           "some new token"
         }
         expect_any_instance_of(User).to receive(:update_access_token)
-        user.access_token
+        user.google_access_token
       end
     end
 
@@ -126,7 +126,7 @@ describe User do
 
       it "returns the current token" do
         expect_any_instance_of(User).not_to receive(:update_access_token)
-        expect(user.access_token).to eq("some token")
+        expect(user.google_access_token).to eq("some token")
       end
     end
   end


### PR DESCRIPTION
resolves #499 

This is a pretty big PR, I've added new fields to user model for storing the google refresh token as well as token expiration time.

A note on the google refresh token, it appears that google only issues these once per app the first time a user gives an app permission such as google calendar/profile access. In order to force google to issue new refresh keys for existing accounts, I've added the userinfo.profile scope to the google omniauth initializer, this was recommended by the team behind the gem on a similar issue.

Also explicitly specifying approval_prompt config was necessary.

This worked for me in dev, but I'm paranoid about it working the same way in production.

So I'm posting this as a WIP right now.

Before it goes live I'll write up a fallback that explicitly signs a person out, and redirects them to signin if the update_access_token method is hit but no refresh_token exists.


