### PR TITLE
Updating default font to latest version for better i18n support

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -426,7 +426,7 @@ a.page_search:hover {
 .headline {
   color: $header-text-color;
   font-size: $page-title;
-  text-shadow: 0px 0px 10px $font-family;
+  text-shadow: 0px 0px 10px $header-text-color;
 
   @media screen and (max-width: $medium) {
     font-size: $font30;

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -1,5 +1,5 @@
 // This file contains the base fonts for the application.
 
-$font-family: -apple-system, BlinkMacSystemFont,
-  'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
-  'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+@import url(https://fonts.googleapis.com/css?family=Roboto:100,400,300);
+
+$font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -1,5 +1,5 @@
 // This file contains the base fonts for the application.
 
-@import url(https://fonts.googleapis.com/css?family=Lato:100,400,300);
-
-$font-family: 'Lato';
+$font-family: -apple-system, BlinkMacSystemFont,
+  'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
+  'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -1,5 +1,41 @@
 // This file contains the base fonts for the application.
 
-@import url(https://fonts.googleapis.com/css?family=Roboto:100,400,300);
+$font-cdn-base: 'https://cdn.jsdelivr.net/font-lato/2.0/Lato';
 
-$font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+/* Webfont: Lato-Thin */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Thin.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Thin.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Thin.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Thin.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 100;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Light */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Light.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Light.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Light.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Light.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 300;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Regular */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Regular.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Regular.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Regular.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 400;
+  text-rendering: optimizeLegibility;
+}
+
+$font-family: 'Lato', sans-serif;


### PR DESCRIPTION
Lato support for Vietnamese is lacking; Roboto has better support for it, as well as having font-weights 100 and 300. San Francisco and Segoe UI (in the latest OS X and Windows OS) will be primary default, but we can fall back to Roboto if they aren't available.