### PR TITLE
Completing Lato family CSS reference

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -426,7 +426,7 @@ a.page_search:hover {
 .headline {
   color: $header-text-color;
   font-size: $page-title;
-  text-shadow: 0px 0px 10px $font-family;
+  text-shadow: 0px 0px 10px $header-text-color;
 
   @media screen and (max-width: $medium) {
     font-size: $font30;

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -1,5 +1,5 @@
 // This file contains the base fonts for the application.
 
-$font-family: -apple-system, BlinkMacSystemFont,
-  'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
-  'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+@import url(https://fonts.googleapis.com/css?family=Roboto:100,400,300);
+
+$font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -1,5 +1,5 @@
 // This file contains the base fonts for the application.
 
-@import url(https://fonts.googleapis.com/css?family=Lato:100,400,300);
-
-$font-family: 'Lato';
+$font-family: -apple-system, BlinkMacSystemFont,
+  'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
+  'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -2,6 +2,30 @@
 
 $font-cdn-base: 'https://cdn.jsdelivr.net/font-lato/2.0/Lato';
 
+/* Webfont: Lato-Hairline */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Hairline.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Hairline.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Hairline.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Hairline.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 100;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-HairlineItalic */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Hairline.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Hairline.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Hairline.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Hairline.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 100;
+  text-rendering: optimizeLegibility;
+}
+
 /* Webfont: Lato-Thin */
 @font-face {
   font-family: 'Lato';
@@ -10,7 +34,19 @@ $font-cdn-base: 'https://cdn.jsdelivr.net/font-lato/2.0/Lato';
        url('#{$font-cdn-base}/Lato-Thin.woff') format('woff'), /* Modern Browsers */
        url('#{$font-cdn-base}/Lato-Thin.ttf') format('truetype');
   font-style: normal;
-  font-weight: 100;
+  font-weight: 200;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-ThinItalic */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-ThinItalic.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-ThinItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-ThinItalic.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-ThinItalic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 200;
   text-rendering: optimizeLegibility;
 }
 
@@ -26,6 +62,18 @@ $font-cdn-base: 'https://cdn.jsdelivr.net/font-lato/2.0/Lato';
   text-rendering: optimizeLegibility;
 }
 
+/* Webfont: Lato-LightItalic */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-LightItalic.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-LightItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-LightItalic.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-LightItalic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 300;
+  text-rendering: optimizeLegibility;
+}
+
 /* Webfont: Lato-Regular */
 @font-face {
   font-family: 'Lato';
@@ -35,6 +83,138 @@ $font-cdn-base: 'https://cdn.jsdelivr.net/font-lato/2.0/Lato';
        url('#{$font-cdn-base}/Lato-Regular.ttf') format('truetype');
   font-style: normal;
   font-weight: 400;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Italic */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Italic.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Italic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Italic.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Italic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 400;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Medium */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Medium.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Medium.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Medium.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Medium.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 500;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-MediumItalic */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-MediumItalic.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-MediumItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-MediumItalic.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-MediumItalic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 500;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Semibold */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Semibold.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Semibold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Semibold.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Semibold.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 600;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-SemiboldItalic */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-SemiboldItalic.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-SemiboldItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-SemiboldItalic.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-SemiboldItalic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 600;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Bold */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Bold.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Bold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Bold.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Bold.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 700;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-BoldItalic */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-BoldItalic.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-BoldItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-BoldItalic.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-BoldItalic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 700;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Heavy */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Heavy.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Heavy.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Heavy.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Heavy.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 800;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-HeavyItalic */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-HeavyItalic.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-HeavyItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-HeavyItalic.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-HeavyItalic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 800;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Black */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Black.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Black.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Black.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Black.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 900;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-BlackItalic */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-BlackItalic.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-BlackItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-BlackItalic.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-BlackItalic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 900;
   text-rendering: optimizeLegibility;
 }
 

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -17,10 +17,10 @@ $font-cdn-base: 'https://cdn.jsdelivr.net/font-lato/2.0/Lato';
 /* Webfont: Lato-HairlineItalic */
 @font-face {
   font-family: 'Lato';
-  src: url('#{$font-cdn-base}/Lato-Hairline.eot'); /* IE9 Compat Modes */
-  src: url('#{$font-cdn-base}/Lato-Hairline.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-       url('#{$font-cdn-base}/Lato-Hairline.woff') format('woff'), /* Modern Browsers */
-       url('#{$font-cdn-base}/Lato-Hairline.ttf') format('truetype');
+  src: url('#{$font-cdn-base}/Lato-HairlineItalic.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-HairlineItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-HairlineItalic.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-HairlineItalic.ttf') format('truetype');
   font-style: italic;
   font-weight: 100;
   text-rendering: optimizeLegibility;

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -1,5 +1,41 @@
 // This file contains the base fonts for the application.
 
-@import url(https://fonts.googleapis.com/css?family=Roboto:100,400,300);
+$font-cdn-base: 'https://cdn.jsdelivr.net/font-lato/2.0/Lato';
 
-$font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+/* Webfont: Lato-Thin */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Thin.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Thin.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Thin.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Thin.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 100;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Light */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Light.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Light.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Light.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Light.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 300;
+  text-rendering: optimizeLegibility;
+}
+
+/* Webfont: Lato-Regular */
+@font-face {
+  font-family: 'Lato';
+  src: url('#{$font-cdn-base}/Lato-Regular.eot'); /* IE9 Compat Modes */
+  src: url('#{$font-cdn-base}/Lato-Regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('#{$font-cdn-base}/Lato-Regular.woff') format('woff'), /* Modern Browsers */
+       url('#{$font-cdn-base}/Lato-Regular.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 400;
+  text-rendering: optimizeLegibility;
+}
+
+$font-family: 'Lato', sans-serif;


### PR DESCRIPTION
This is a follow-up to PR #526 on issue #525. I noticed that there were some places where we used the bold version of the font, and it was not listed in CSS definition file. It doesn't hurt to list out all 9 font weights with italic variation; the browser is smart enough to download the file only if that variant is used.