### PR TITLE
DRY out simple controller redirects

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -19,10 +19,7 @@ class CategoriesController < ApplicationController
       @page_edit = edit_category_path(@category)
       @page_tooltip = t('categories.edit_category')
     else
-      respond_to do |format|
-        format.html { redirect_to categories_path }
-        format.json { head :no_content }
-      end
+      redirect_to_path(categories_path)
     end
   end
 
@@ -35,10 +32,7 @@ class CategoriesController < ApplicationController
   def edit
     return if @category.userid == current_user.id
 
-    respond_to do |format|
-      format.html { redirect_to category_path(@category) }
-      format.json { head :no_content }
-    end
+    redirect_to_path(category_path(@category))
   end
 
   # POST /categories
@@ -64,10 +58,7 @@ class CategoriesController < ApplicationController
     Category.create(userid: current_user.id, name: t('categories.index.premade3_name'), description: t('categories.index.premade3_description'))
     Category.create(userid: current_user.id, name: t('categories.index.premade4_name'), description: t('categories.index.premade4_description'))
 
-    respond_to do |format|
-      format.html { redirect_to categories_path }
-      format.json { render :no_content }
-    end
+    redirect_to_path(categories_path)
   end
 
   # PATCH/PUT /categories/1
@@ -97,10 +88,8 @@ class CategoriesController < ApplicationController
     end
 
     @category.destroy
-    respond_to do |format|
-      format.html { redirect_to categories_path }
-      format.json { head :no_content }
-    end
+
+    redirect_to_path(categories_path)
   end
 
   def quick_create
@@ -122,10 +111,7 @@ class CategoriesController < ApplicationController
   def set_category
     @category = Category.friendly.find(params[:id])
   rescue
-    respond_to do |format|
-      format.html { redirect_to categories_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(categories_path)
   end
 
   def category_params

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -114,10 +114,7 @@ class GroupsController < ApplicationController
   def set_group
     @group = Group.friendly.find(params[:id])
   rescue ActiveRecord::RecordNotFound
-    respond_to do |format|
-      format.html { redirect_to groups_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(groups_path)
   end
 
   def group_params
@@ -153,10 +150,7 @@ class GroupsController < ApplicationController
   end
 
   def redirect_to_index
-    respond_to do |format|
-      format.html { redirect_to groups_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(groups_path)
   end
 
   def render_new(errors)

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -19,10 +19,7 @@ class MedicationsController < ApplicationController
       @page_edit = edit_medication_path(@medication)
       @page_tooltip = t('medications.edit_medication')
     else
-      respond_to do |format|
-        format.html { redirect_to medications_path }
-        format.json { head :no_content }
-      end
+      redirect_to_path(medications_path)
     end
   end
 
@@ -39,10 +36,7 @@ class MedicationsController < ApplicationController
     RefillReminder.find_or_initialize_by(medication_id: @medication.id)
     return if @medication.userid == current_user.id
 
-    respond_to do |format|
-      format.html { redirect_to medication_path(@medication) }
-      format.json { head :no_content }
-    end
+    redirect_to_path(medication_path(@medication))
   end
 
   # POST /medications
@@ -73,18 +67,12 @@ class MedicationsController < ApplicationController
   # DELETE /medications/1.json
   def destroy
     @medication.destroy
-    respond_to do |format|
-      format.html { redirect_to medications_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(medications)
   end
 
   def return_to_sign_in
     sign_out current_user
-    respond_to do |format|
-      format.html { redirect_to new_user_session_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(new_user_session_path)
     false
   end
 
@@ -111,10 +99,7 @@ class MedicationsController < ApplicationController
   def set_medication
     @medication = Medication.friendly.find(params[:id])
   rescue
-    respond_to do |format|
-      format.html { redirect_to medications_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(medications_path)
   end
 
   def medication_params

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -18,10 +18,7 @@ class MeetingsController < ApplicationController
 
     @no_hide_page = false
     if hide_page(@meeting)
-      respond_to do |format|
-        format.html { redirect_to group_path(@meeting.groupid) }
-        format.json { head :no_content }
-      end
+      redirect_to_path(group_path(@meeting.groupid))
     else
       @comment = Comment.new
       @comments = Comment.where(commented_on: @meeting.id, comment_type: 'meeting').all.order('created_at DESC')
@@ -321,10 +318,8 @@ class MeetingsController < ApplicationController
 
     groupid = @meeting.groupid
     @meeting.destroy
-    respond_to do |format|
-      format.html { redirect_to group_path(groupid) }
-      format.json { head :no_content }
-    end
+
+    redirect_to_path(group_path(groupid))
   end
 
   private
@@ -333,20 +328,14 @@ class MeetingsController < ApplicationController
   def set_meeting
     @meeting = Meeting.friendly.find(params[:id])
   rescue
-    respond_to do |format|
-      format.html { redirect_to groups_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(groups_path)
   end
 
   # Checks if user is a meeting leader, if not redirect to group_path
   def not_a_leader(groupid)
     return if GroupMember.where(groupid: groupid, userid: current_user.id, leader: true).exists?
 
-    respond_to do |format|
-      format.html { redirect_to group_path(groupid) }
-      format.json { head :no_content }
-    end
+    redirect_to_path(group_path(groupid))
   end
 
   def meeting_params

--- a/app/controllers/moments_controller.rb
+++ b/app/controllers/moments_controller.rb
@@ -80,10 +80,7 @@ class MomentsController < ApplicationController
   # GET /moments/1/edit
   def edit
     unless @moment.userid == current_user.id
-      return respond_to do |format|
-        format.html { redirect_to moment_path(@moment) }
-        format.json { head :no_content }
-      end
+      redirect_to_path(moment_path(@moment))
     end
 
     set_association_variables!
@@ -130,10 +127,7 @@ class MomentsController < ApplicationController
   # DELETE /moments/1.json
   def destroy
     @moment.destroy
-    respond_to do |format|
-      format.html { redirect_to moments_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(moments_path)
   end
 
   private
@@ -141,10 +135,7 @@ class MomentsController < ApplicationController
   def set_moment
     @moment = Moment.friendly.find(params[:id])
   rescue
-    respond_to do |format|
-      format.html { redirect_to moments_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(moments_path)
   end
 
   def moment_params

--- a/app/controllers/moods_controller.rb
+++ b/app/controllers/moods_controller.rb
@@ -18,10 +18,7 @@ class MoodsController < ApplicationController
       @page_edit = edit_mood_path(@mood)
       @page_tooltip = t('moods.edit_mood')
     else
-      respond_to do |format|
-        format.html { redirect_to moods_path }
-        format.json { head :no_content }
-      end
+      redirect_to_path(moods_path)
     end
   end
 
@@ -33,11 +30,7 @@ class MoodsController < ApplicationController
   # GET /moods/1/edit
   def edit
     return if @mood.userid == current_user.id
-
-    respond_to do |format|
-      format.html { redirect_to mood_path(@mood) }
-      format.json { head :no_content }
-    end
+    redirect_to_path(mood_path(@mood))
   end
 
   # POST /moods
@@ -64,10 +57,7 @@ class MoodsController < ApplicationController
     Mood.create(userid: current_user.id, name: t('moods.index.premade4_name'), description: t('moods.index.premade4_description'))
     Mood.create(userid: current_user.id, name: t('moods.index.premade5_name'), description: t('moods.index.premade5_description'))
 
-    respond_to do |format|
-      format.html { redirect_to moods_path }
-      format.json { render :no_content }
-    end
+    redirect_to_path(moods_path)
   end
 
   # PATCH/PUT /moods/1
@@ -97,10 +87,7 @@ class MoodsController < ApplicationController
     end
 
     @mood.destroy
-    respond_to do |format|
-      format.html { redirect_to moods_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(moods_path)
   end
 
   def quick_create
@@ -121,10 +108,7 @@ class MoodsController < ApplicationController
   def set_mood
     @mood = Mood.friendly.find(params[:id])
   rescue
-    respond_to do |format|
-      format.html { redirect_to moods_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(moods_path)
   end
 
   def mood_params

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,10 +6,7 @@ class SearchController < ApplicationController
     raise ActionController::ParameterMissing if permitted.blank?
     @matching_users = search_by_email(permitted[:email].strip)
   rescue ActionController::ParameterMissing
-    respond_to do |format|
-      format.html { redirect_to allies_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(allies_path)
   end
 
   def posts
@@ -18,10 +15,7 @@ class SearchController < ApplicationController
 
     return unless data_type.in?(%w[moment category mood strategy medication])
 
-    respond_to do |format|
-      format.html { redirect_to make_path(term, data_type) }
-      format.json { head :no_content }
-    end
+    redirect_to_path(make_path(term, data_type))
   end
 
   private

--- a/app/controllers/strategies_controller.rb
+++ b/app/controllers/strategies_controller.rb
@@ -83,10 +83,7 @@ class StrategiesController < ApplicationController
       @category = Category.new
       PerformStrategyReminder.find_or_initialize_by(strategy_id: @strategy.id)
     else
-      respond_to do |format|
-        format.html { redirect_to strategy_path(@strategy) }
-        format.json { head :no_content }
-      end
+      redirect_to_path(strategy_path(@strategy))
     end
   end
 
@@ -160,10 +157,7 @@ class StrategiesController < ApplicationController
     end
 
     @strategy.destroy
-    respond_to do |format|
-      format.html { redirect_to strategies_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(strategies_path)
   end
 
   private
@@ -176,10 +170,7 @@ class StrategiesController < ApplicationController
   def set_strategy
     @strategy = Strategy.friendly.find(params[:id])
   rescue
-    respond_to do |format|
-      format.html { redirect_to strategies_path }
-      format.json { head :no_content }
-    end
+    redirect_to_path(strategies_path)
   end
 
   def strategy_params


### PR DESCRIPTION
## Summary
This refactor addresses #564 and replaces 

```
respond_to do |format|
  format.html { redirect_to moods_path }
  format.json { head :no_content }
end
```

with the `redirect_to_path` method in the following controllers:
- categories
- groups
- medications
- meetings
- moments
- moods
- search
- strategies

## Notes
Hi @julianguyen! I tried to make sure I "broke" tests by (1) commenting out redirects, (2) replacing existing code with `redirect_to_path` (3) making sure tests passed again. 

But there were a couple of places where controller test coverage could be improved. In particular :
- `medications_controller_spec.rb`
- `meetings_controller_spec.rb`
- `moments_controller_spec`

These could be good tickets to add to Improving Test Coverage, something like #534.