### PR TITLE
Set expires headers on assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,6 +90,10 @@ Rails.application.configure do
   end
 
   config.public_file_server.enabled = true
+  config.public_file_server.headers = {
+    'Cache-Control' => "public, maxage=#{1.year.to_i}",
+    'Expires' => 1.year.from_now.to_formatted_s(:rfc822)
+  }
   config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
   config.assets.compile = true
 


### PR DESCRIPTION
Since Heroku connects requests directly to the Ruby web server, managing the
response headers used on assets (CSS, JS, images, etc.) needs to be handled by
Rails. By setting an expiry in the future, the web browser is directed to cache
the assets and reload from memory instead of hitting the server again for a new
copy of the same file