### PR TITLE
Use googleapis CDN for jQuery UI CSS

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
       <%= tag :meta, :name => "pusher-key", :content => ENV['PUSHER_KEY'] %>
     <% end %>
     <!-- jQuery UI -->
-    <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/jquery.ui/1.10.3/themes/flick/jquery-ui.min.css" />
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/flick/jquery-ui.min.css" />
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
     <style type="text/css">
       .ui-menu .ui-menu-item a,.ui-menu .ui-menu-item a.ui-state-hover, .ui-menu .ui-menu-item a.ui-state-active {


### PR DESCRIPTION
There are two different CDNs being used to load jQuery UI; one for the JS and
one for the CSS. Not only does this cause the browser to do an extra DNS lookup
but aspnetcdn is not gzipping the CSS file. In this case, gzip reduces the file
by 80%