### PR TITLE
 [#627] Updates readme for starting server

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Run `rake slugs:slugify` to update existing entries in the database with slugs
 
 Start the local server:
 ```
-rails s
+foreman start -f Procfile.dev
 ```
 
 To view the app, go to `http://localhost:3000`.


### PR DESCRIPTION
This fixes issue [#627](https://github.com/julianguyen/ifme/issues/627) where starting `rails s` would produce a console error.

Updated instructions to start server with `foreman start -f Procfile.dev`