### PR TITLE
Adding gzip compression for webpack assets

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -47,6 +47,7 @@
     "babel-eslint": "^7.2.3",
     "babel-plugin-flow-react-proptypes": "^4.1.0",
     "babel-preset-flow": "^6.23.0",
+    "compression-webpack-plugin": "^1.0.0",
     "css-loader": "^0.28.7",
     "empty": "^0.10.1",
     "enzyme": "^2.9.1",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -5,6 +5,7 @@
 const webpack = require('webpack');
 const { resolve } = require('path');
 
+const CompressionPlugin = require('compression-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -56,6 +57,13 @@ const config = {
     }),
     new ManifestPlugin({ fileName: manifest, writeToFileEmit: true }),
     new ExtractTextPlugin(`${outputFilename}.css`),
+    new CompressionPlugin({
+      asset: '[path].gz[query]',
+      algorithm: 'gzip',
+      test: /\.js$|\.css$|\.html$/,
+      threshold: 10240,
+      minRatio: 0.8
+    }),
   ].concat(devBuild ? [] : [
     new OptimizeCssAssetsPlugin({
       cssProcessorOptions: {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -8,7 +8,7 @@ const { resolve } = require('path');
 const CompressionPlugin = require('compression-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
-const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+// const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const webpackConfigLoader = require('react-on-rails/webpackConfigLoader');
 
 const configPath = resolve('..', 'config');
@@ -59,12 +59,15 @@ const config = {
     new ExtractTextPlugin(`${outputFilename}.css`),
   ].concat(devBuild ? [] : [
     /**
-     * OptimizeCssAssetsPlugin doesn't play nicely with CompressionPlugin; enabling OptimizeCssAssetsPlugin
-     * prevents the CSS from being gzipped. Since we use OptimizeCssAssetsPlugin primarily to remove
-     * comments, I value gzip over comment removal for now.
+     * OptimizeCssAssetsPlugin doesn't play nicely with CompressionPlugin; enabling
+     * OptimizeCssAssetsPlugin prevents the CSS from being gzipped. Since we use
+     * OptimizeCssAssetsPlugin primarily to remove comments, I value gzip over comment
+     * removal for now.
      *
      * A GitHub issue is already filed for this problem:
      * https://github.com/webpack-contrib/compression-webpack-plugin/issues/62
+     *
+     * Re-enable this plugin once the issue has been resolved.
      */
     // new OptimizeCssAssetsPlugin({
     //   cssProcessorOptions: {
@@ -78,7 +81,7 @@ const config = {
       algorithm: 'gzip',
       test: /\.(js|css|html)$/,
       threshold: 10240,
-      minRatio: 0.8
+      minRatio: 0.8,
     }),
   ]),
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -57,20 +57,28 @@ const config = {
     }),
     new ManifestPlugin({ fileName: manifest, writeToFileEmit: true }),
     new ExtractTextPlugin(`${outputFilename}.css`),
+  ].concat(devBuild ? [] : [
+    /**
+     * OptimizeCssAssetsPlugin doesn't play nicely with CompressionPlugin; enabling OptimizeCssAssetsPlugin
+     * prevents the CSS from being gzipped. Since we use OptimizeCssAssetsPlugin primarily to remove
+     * comments, I value gzip over comment removal for now.
+     *
+     * A GitHub issue is already filed for this problem:
+     * https://github.com/webpack-contrib/compression-webpack-plugin/issues/62
+     */
+    // new OptimizeCssAssetsPlugin({
+    //   cssProcessorOptions: {
+    //     discardComments: {
+    //       removeAll: true,
+    //     },
+    //   },
+    // }),
     new CompressionPlugin({
       asset: '[path].gz[query]',
       algorithm: 'gzip',
-      test: /\.js$|\.css$|\.html$/,
+      test: /\.(js|css|html)$/,
       threshold: 10240,
       minRatio: 0.8
-    }),
-  ].concat(devBuild ? [] : [
-    new OptimizeCssAssetsPlugin({
-      cssProcessorOptions: {
-        discardComments: {
-          removeAll: true,
-        },
-      },
     }),
   ]),
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -386,6 +386,12 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
+async@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.4.1.tgz#62a56b279c98a11d0987096a01cc3eeb8eb7bbd7"
+  dependencies:
+    lodash "^4.14.0"
+
 async@^2.1.2, async@^2.1.4, async@^2.1.5:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
@@ -1823,6 +1829,13 @@ component-emitter@1.2.1, component-emitter@^1.2.0:
 component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
+
+compression-webpack-plugin@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-1.0.0.tgz#5c5eb6afd08ca6a5d66006eeef71da17b01bd676"
+  dependencies:
+    async "2.4.1"
+    webpack-sources "^1.0.1"
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
Tested via development mode (confirmed Content-Encoding:gzip was in the headers). The webpack JavaScript bundle dropped from 755 kB to 230 kB.