### PR TITLE
Centering icons in footer

### DIFF
--- a/app/assets/stylesheets/application/footer.scss
+++ b/app/assets/stylesheets/application/footer.scss
@@ -117,7 +117,7 @@
 		padding-right: 80px;
 	}
 
-	@medium screen and (max-width: $medium) {
+	@media screen and (max-width: $medium) {
 		.large_padding_right {
 			padding-right: 40px;
 		}
@@ -167,4 +167,9 @@
 		text-align: center;
 		margin-top: 10px;
 	}
+}
+
+#connect_links ~ a .fa {
+	text-align: center;
+	width: 1em;
 }


### PR DESCRIPTION
Sorry, it just annoyed me not seeing symmetry.

<img width="219" alt="screen shot 2017-09-18 at 4 19 27 pm" src="https://user-images.githubusercontent.com/4228012/30569000-2fe615c6-9c8d-11e7-85d8-b1a8ac3ecd98.png">

<img width="213" alt="screen shot 2017-09-18 at 4 10 13 pm" src="https://user-images.githubusercontent.com/4228012/30568919-b6bbd15e-9c8c-11e7-9274-cdabcfbe16ac.png">
