### PR TITLE
Add medications controller tests

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -8,9 +8,9 @@ class MedicationsController < ApplicationController
 
   # GET /medications
   # GET /medications.json
-  # def index
-  #   page_collection('@medications', 'medication')
-  # end
+  def index
+    page_collection('@medications', 'medication')
+  end
 
   # GET /medications/1
   # GET /medications/1.json

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -8,9 +8,9 @@ class MedicationsController < ApplicationController
 
   # GET /medications
   # GET /medications.json
-  def index
-    page_collection('@medications', 'medication')
-  end
+  # def index
+  #   page_collection('@medications', 'medication')
+  # end
 
   # GET /medications/1
   # GET /medications/1.json

--- a/spec/controllers/medications_controller_spec.rb
+++ b/spec/controllers/medications_controller_spec.rb
@@ -77,7 +77,7 @@ describe MedicationsController do
     end 
   end 
 
-  describe 'POST new' do 
+  describe 'GET #new' do 
     let(:user) { create(:user) }
     let(:medication) { create(:medication, user: user) }
 
@@ -90,8 +90,29 @@ describe MedicationsController do
     end 
 
     context 'when not signed in' do 
-      before { post :new }
+      before { get :new }
       it_behaves_like :with_no_logged_in_user
     end 
   end 
+
+  describe 'GET #show' do 
+    let(:user) { create(:user) }
+    let(:medication) { create(:medication, user: user) }
+
+    context 'when signed in' do 
+      before { sign_in user }
+      it 'render the show page' do
+        medication.save! 
+        get :show, params: { id: medication.id }
+        expect(response).to render_template(:show)
+      end 
+    end 
+
+    context 'when not signed in' do 
+      before { get :show, params: { id: medication.id } }
+      it_behaves_like :with_no_logged_in_user
+    end 
+  end 
+
+
 end

--- a/spec/controllers/medications_controller_spec.rb
+++ b/spec/controllers/medications_controller_spec.rb
@@ -59,4 +59,39 @@ describe MedicationsController do
       end
     end
   end
+
+  describe 'GET #index' do 
+    let(:user) { create(:user) }
+    let!(:medication) { create(:medication, user: user) }
+
+    context 'when signed in' do 
+      before { sign_in user }
+      it 'renders index page' do 
+        get :index 
+        expect(response).to render_template(:index)  
+      end 
+    end 
+    context 'when not signed in' do 
+      before { get :index }
+      it_behaves_like :with_no_logged_in_user
+    end 
+  end 
+
+  describe 'POST new' do 
+    let(:user) { create(:user) }
+    let(:medication) { create(:medication, user: user) }
+
+    context 'when signed in' do 
+      before { sign_in user }
+      it 'renders the new page' do 
+        get :new
+        expect(response).to render_template(:new)
+      end 
+    end 
+
+    context 'when not signed in' do 
+      before { post :new }
+      it_behaves_like :with_no_logged_in_user
+    end 
+  end 
 end


### PR DESCRIPTION
Fixes issue #679 
This adds tests to `medications_controller_spec` for the following actions: 
- index 
- show
- new 

I was following the style from `moments_controller_spec`. 
I am a little puzzled because my tests still pass even when I comment out the controller actions. Any ideas? The files are still being rendered. Alternatively, if anyone is free to pair I am generally free Mon-Fri from 2-6pm PST. 