### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ add your name and desired social media link to `doc/pages/contributors.json`.
 
 Below are folks who have contributed via GitHub!
 
-<a href="graphs/contributors"><img src="https://opencollective.com/ifme/contributors.svg?width=890" /></a>
+<a href="https://github.com/julianguyen/ifme/graphs/contributors"><img src="https://opencollective.com/ifme/contributors.svg?width=890" /></a>
 
 ## Donate
 


### PR DESCRIPTION
The old link redirects to https://github.com/julianguyen/ifme/blob/master/graphs/contributors which does not exist at all, I just edited to https://github.com/julianguyen/ifme/graphs/contributors :)

Thanks!