### PR TITLE
accept any version of ruby 2.3 in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '2.3.4'
+ruby '~> 2.3.4'
 
 gem 'puma'
 gem 'rack-rewrite'


### PR DESCRIPTION
according the heroku docs it's recommended to accept a wider range of ruby versions in the gemfile https://devcenter.heroku.com/articles/ruby-versions

This will help people avoid errors because their ruby version is a slight mismatch