### PR TITLE
Fix Validations for Medication Create

### DIFF
--- a/app/views/medications/_form.html.erb
+++ b/app/views/medications/_form.html.erb
@@ -1,10 +1,5 @@
 <div id="medication_content">
   <%= form_for(@medication) do |f| %>
-  <% if @medication.errors.any? %>
-    <div class="error_explanation">
-      <%= t('common.form.error_explanation') %>
-    </div>
-  <% end %>
 
   <div class="table">
 

--- a/app/views/medications/_validation_errors.html.erb
+++ b/app/views/medications/_validation_errors.html.erb
@@ -1,0 +1,7 @@
+<%= form_for(@medication) do |f| %>
+  <% if @medication.errors.any? %>
+    <div class="error_explanation">
+      <%= t('common.form.error_explanation') %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/medications/edit.html.erb
+++ b/app/views/medications/edit.html.erb
@@ -1,4 +1,4 @@
 <% title "#{t('common.actions.edit_instance', instance: @medication.name)}" %>
 
-<%= render 'validation_errors.html.erb' %>
+<%= render 'validation_errors' %>
 <%= render 'form' %>

--- a/app/views/medications/edit.html.erb
+++ b/app/views/medications/edit.html.erb
@@ -1,2 +1,4 @@
 <% title "#{t('common.actions.edit_instance', instance: @medication.name)}" %>
+
+<%= render 'validation_errors.html.erb' %>
 <%= render 'form' %>

--- a/app/views/medications/new.html.erb
+++ b/app/views/medications/new.html.erb
@@ -1,2 +1,4 @@
 <% title "#{t('medications.new')}" %>
+
+<%= render 'validation_errors' %>
 <%= render 'form' %>


### PR DESCRIPTION
### Fixes a part of: https://github.com/julianguyen/ifme/issues/682
More fixes here! https://github.com/julianguyen/ifme/pull/721

### Change Log

- The else case the Medication Create action triggered when fields are not filled out (code snippets below) seems to reload the page, wiping out `medication.errors.messages`. Moving the medication validations into partial to avoids missing them because of page reload.  Validations now work properly for both create and edit. 

```
def create
    @medication = Medication.new(medication_params)
    return unless save_refill_to_google_calendar(@medication)

    if @medication.save
      redirect_to_medication(@medication)
    else
      render_unprocessable_medication
    end
  end
```
```
...
private

  def render_unprocessable_medication
    respond_to do |format|
      format.html { render :new }
      format.json do
        render(json: @medication.errors,
               status: :unprocessable_entity)
      end
    end
  end
```