### PR TITLE
Fixing test for persisting locale after sign in

### DIFF
--- a/spec/features/persisting_browser_locale_after_sign_in_spec.rb
+++ b/spec/features/persisting_browser_locale_after_sign_in_spec.rb
@@ -10,7 +10,10 @@ RSpec.feature 'Persisting browser locale after sign in', type: :feature do
 
     within('span#title_expand') { find('i.expand').click }
     within('ul#expand_me') { find('a[href="/users/sign_out"]').click }
+    expect(find('a[href="/users/sign_in"]')).to have_content('Sign in')
     select 'Español', from: 'locale'
+    expect(find('a[href="/users/sign_in"]')).to have_content('Ingresar')
+
     login_as user
     visit moments_path
 


### PR DESCRIPTION
Added some expects that wait for elements to appear before moving on. I suspect the page hasn't finished loading when the next step in the test starts to immediately run.

For issue #723 