### PR TITLE
Changes to devise.de.yml as proposed by suggestlang util

### DIFF
--- a/config/locales/devise.de.yml
+++ b/config/locales/devise.de.yml
@@ -1,12 +1,12 @@
 # if me: DO NOT modify this file. if you need to add translations, add them to sv.yml
 # Additional translations at https://github.com/plataformatec/devise/wiki/I18n
 
-sv:
+de:
   devise:
     confirmations:
-      confirmed: "Deine E-Mailadresse wurde erfolgreich bestätigt."
-      send_instructions: "Du wirst in einigen Minuten eine E-Mail erhalten mit Anweisungen, wie du deine E-Mailadresse bestätigen kannst."
-      send_paranoid_instructions: "Wenn deine E-Mailadresse in unserer Datenbank bereits existiert, wirst du in einigen Minuten eine E-Mail erhalten mit Anweisungen, wie du deine E-Mailadresse bestätigen kannst."
+      confirmed: "Deine E-Mail-Adresse wurde erfolgreich bestätigt."
+      send_instructions: "Du wirst in einigen Minuten eine E-Mail erhalten mit Anweisungen, wie du deine E-Mail-Adresse bestätigen kannst."
+      send_paranoid_instructions: "Wenn deine E-Mail-Adresse in unserer Datenbank bereits existiert, wirst du in einigen Minuten eine E-Mail erhalten mit Anweisungen, wie du deine E-Mail-Adresse bestätigen kannst."
 
     failure:
       already_authenticated: "Du bist schon eingeloggt."
@@ -17,13 +17,17 @@ sv:
       not_found_in_database: "Ungültige %{authentication_keys} oder Passwort."
       timeout: "Deine Sitzung ist abgelaufen. Bitte logge dich erneut ein, um fortzufahren."
       unauthenticated: "Um fortzufahren, musst dich einloggen oder anmelden."
-      unconfirmed: "Du musst deine E-Mailadresse bestätigen, um fortzufahren."
+      unconfirmed: "Du musst deine E-Mail-Adresse bestätigen, um fortzufahren."
 
     mailer:
-      confirmation_instructions: subject: "Anweisungen zur Bestätigung"
-      reset_password_instructions: subject: "Anweisungen zum Zurücksetzen des Passworts"
-      unlock_instructions: subject: "Anweisungen zum Entsperren"
-      password_change: subject: "Passwort geändert"
+      confirmation_instructions:
+        subject: "Anweisungen zur Bestätigung"
+      reset_password_instructions:
+        subject: "Anweisungen zum Zurücksetzen des Passworts"
+      unlock_instructions:
+        subject: "Anweisungen zum Entsperren"
+      password_change:
+        subject: "Passwort geändert"
 
     omniauth_callbacks:
       failure: "Konnte dich nicht bestätigen %{kind}, weil \"%{reason}\"."
@@ -32,17 +36,17 @@ sv:
     passwords:
       no_token: "Du kannst auf diese Seite nicht zugreifen, ohne von einer E-Mail zum Zurücksetzen des Passworts zu kommen. Wenn du von einer E-Mail zum Zurücksetzen des Passworts kommst, stelle sicher, dass du die komplette URL verwendet hast."
       send_instructions: "Du wirst in einigen Minuten eine E-Mail erhalten mit Anweisungen, wie du dein Passwort zurücksetzen kannst."
-      send_paranoid_instructions: "Wenn deine E-Mailadresse bereits in unserer Datenbank existiert, wirst du in einigen Minuten eine E-Mail erhalten mit einem Link zur Passwortwiederherstellung."
+      send_paranoid_instructions: "Wenn deine E-Mail-Adresse bereits in unserer Datenbank existiert, wirst du in einigen Minuten eine E-Mail erhalten mit einem Link zur Passwortwiederherstellung."
       updated: "Dein Passwort wurde erfolgreich geändert. Du bist nun eingeloggt."
       updated_not_active: "Dein Passwort wurde erfolgreich geändert."
 
     registrations:
       destroyed: "Tschüss! Dein Account wurde erfolgreich gelöscht. Wir hoffen, dich bald wiederzusehen."
       signed_up: "Willkommen! Du hast dich erfolgreich angemeldet."
-      signed_up_but_inactive: "Du hast dich erfolgreich angemeldet. Wir konnten dich jedoch nicht nicht einloggen, weil dein Account noch nicht freigeschaltet ist."
-      signed_up_but_locked: "Du hast dich erfolgreich angemeldet. Wir konnten dich jedoch nicht nicht einloggen, weil dein Account gesperrt ist."
-      signed_up_but_unconfirmed: "Eine Nachricht mit dem Bestätigungslink ist an deine E-Mailadresse gesendet worden. Bitte folge dem Link, um deinen Account freizuschalten."
-      update_needs_confirmation: "Du hast deinen Account erfolgreich aktualisiert, aber wir müssen deine neue E-Mailadresse bestätigen. Bitte checke deine E-Mails und folge dem Link, um deine neue E-Mailadresse zu bestätigen."
+      signed_up_but_inactive: "Du hast dich erfolgreich angemeldet. Wir konnten dich jedoch nicht einloggen, weil dein Account noch nicht freigeschaltet ist."
+      signed_up_but_locked: "Du hast dich erfolgreich angemeldet. Wir konnten dich jedoch nicht einloggen, weil dein Account gesperrt ist."
+      signed_up_but_unconfirmed: "Eine Nachricht mit dem Bestätigungslink ist an deine E-Mail-Adresse gesendet worden. Bitte folge dem Link, um deinen Account freizuschalten."
+      update_needs_confirmation: "Du hast deinen Account erfolgreich aktualisiert, aber wir müssen deine neue E-Mail-Adresse bestätigen. Bitte checke deine E-Mails und folge dem Link, um deine neue E-Mail-Adresse zu bestätigen."
       updated: "Dein Account wurde erfolgreich aktualisiert."
 
     sessions:


### PR DESCRIPTION
I have NO CLUE, if merging these branches will work. Not that savvy on working with branches of others, but alas.

Some changes as proposed by the suggestlang.rb tool. Also fixes root key name.
Changed all occurances of E-Mailadresse to E-Mail-Adresse, which looks correcter to me, and seems to be commonly used on websites.

Didn't know what to do with the following warning of LanguageTool. I think "stelle sicher" shouldn't be capitalized, but a native speaker should confirm. (e.g. I think this message is a false positive).

> devise.de.yml@19: de.devise.passwords.no_token
> Original: Du kannst auf diese Seite nicht zugreifen, ohne von einer E-Mail zum Zurücksetzen des Passworts zu kommen. Wenn du von einer E-Mail zum Zurücksetzen des Passworts kommst, stelle sicher, dass du die komplette URL verwendet hast.
> Proposed: Du kannst auf diese Seite nicht zugreifen, ohne von einer E-Mail zum Zurücksetzen des Passworts zu kommen. Wenn du von einer E-Mail zum Zurücksetzen des Passworts kommst, Stelle sicher, dass du die komplette URL verwendet hast.
>  - Bitte prüfen Sie, ob "Stelle" hier als Substantiv gebraucht wird und daher großgeschrieben werden muss.