### PR TITLE
Add char counter on modal editor

### DIFF
--- a/app/views/shared/_editor_modal.html.erb
+++ b/app/views/shared/_editor_modal.html.erb
@@ -9,6 +9,7 @@
     </div>
     <div class="modal_text" id="modal_text">
       <%= cktext_area :modal, :editor, ckeditor: { display:'none', height:'70vh' }, class: 'no_title special_textarea ckeditor' %>
+      <%= render partial: '/shared/character_count', locals: { data: 'modal_editor' } %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This fix enhancement for #712. I have added character count on modal editor. This might add character counter to every text editor that appears when editing in mobile view. 