### PR TITLE
add/change info on group page [wip][skip ci][closes #606]

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,7 +145,7 @@ en:
    available_groups: 'Available Groups'
    joined_groups: 'Joined Groups'
    leader: '(Leader)'
-   instructions: "You aren't a part of any groups yet! Click %{icon} to create one or join any available groups below.<br><br>Support groups are great for having open discussions about mental health! You can create groups, invite members, and organize meetup events online or offline. You can also join groups your allies have created."
+   instructions: "You aren't a part of any groups yet, but you can click %{icon} to create one!<br><br><h1 class=\"faq_heading\"><%= t('pages.faq.group_question') %></h1>"
   join_success: 'You have joined this group.'
   leave:
     error: 'You cannot leave the group, you are the only leader.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -146,7 +146,7 @@ es:
    available_groups: "Grupos disponibles"
    joined_groups: "Grupos a los que te has unido"
    leader: "(Líder)"
-   instructions: "Aún no eres parte de ningún grupo. Da click en %{icon} para crear uno o unirte a cualquiera de los grupos disponibles abajo. <br><br> ¡Los grupos de apoyo son excelentes para tener pláticas sobre salud mental! Puedes crear grupos, invitar miembros, y organizar reuniones en línea o en persona. También te puedes unir a los grupos que tus aliados hayan creado."
+   instructions: "Aún no eres parte de ningún grupo. Da click en %{icon} para crear uno o unirte a cualquiera de los grupos disponibles abajo. <br><br><h1 class=\"faq_heading\"><%= t('pages.faq.group_question') %></h1>"
   join_success: "Te has unido a este grupo"
   leave:
     error: "Eres el único líder, por lo tanto no puedes abandonar el Grupo."

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -145,7 +145,7 @@ nl:
    available_groups: 'Beschikbare groepen'
    joined_groups: 'Groepslidmaatschappen'
    leader: '(Leider)'
-   instructions: "Je bent nog niet lid van een groep! Klik op %{icon} om er een te maken of wordt lid van een van de beschikbare groepen hier onder.<br><br>Ondersteuningsgroepen zijn goed voor het voeren van openbare discussies over geestelijke gezondheid! Je kunt groepen maken, leden uitnodigen en samenkomsten organiseren zowel online als offline. Je kunt ook lid worden van groepen die je bondgenoten hebben gemaakt."
+   instructions: "Je bent nog niet lid van een groep! Klik op %{icon} om er een te maken of wordt lid van een van de beschikbare groepen hier onder.<br><br><h1 class=\"faq_heading\"><%= t('pages.faq.group_question') %></h1>"
   join_success: 'Je bent lid geworden van deze groep.'
   leave:
     error: 'Je kunt de groep niet verlaten, je bent de enige leider van de groep.'

--- a/config/locales/ptbr.yml
+++ b/config/locales/ptbr.yml
@@ -145,7 +145,7 @@ ptbr:
    available_groups: 'Grupos Disponíveis.'
    joined_groups: 'Grupos que participo.'
    leader: '(Líder)'
-   instructions: "Você ainda não participa de grupo nenhum! Clique %{icon} para criar um novo grupo ou entre em qualquer grupo disponível abaixo.<br><br>Dar suporte aos grupos é uma excelente forma de ter discussões abertas sobre saúde mental! Você pode criar grupos, convidar menbros, e organizar reuniões online ou presenciais. Você pode se juntar a grupos que seus aliados criaram."
+   instructions: "Você ainda não participa de grupo nenhum! Clique %{icon} para criar um novo grupo ou entre em qualquer grupo disponível abaixo.<br><br><h1 class=\"faq_heading\"><%= t('pages.faq.group_question') %></h1>"
   join_success: 'Você entrou nesse grupo.'
   leave:
     error: 'Você não pode sair deste grupo, porque você é o único líder.'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -145,7 +145,7 @@ sv:
    available_groups: 'Tillgängliga Grupper'
    joined_groups: 'Grupper du är medlem i'
    leader: '(Ledare)'
-   instructions: "Du är inte medlem i några grupper än! Klicka på %{icon} för att skapa en eller gå med i några tillgängliga grupper nedan. <br> <br> Supportgrupper är bra för att ha öppna diskussioner om mental hälsa! Du kan skapa grupper, bjuda in medlemmar och organisera möteshändelser online eller offline. Du kan också gå med i grupper som dina allierade har skapat."
+   instructions: "Du är inte medlem i några grupper än! Klicka på %{icon} för att skapa en eller gå med i några tillgängliga grupper nedan. <br><br><h1 class=\"faq_heading\"><%= t('pages.faq.group_question') %></h1>"
   join_success: 'Du har gått med i den här gruppen.'
   leave:
     error: 'Du kan inte lämna gruppen, du är den enda ledaren.'


### PR DESCRIPTION
* display more detailed info about groups by using text from FAQ
* wip

I changed part of the EN text (pending approval) to:
You aren't a part of any groups yet, but you can click %{icon} to create one!

Formerly, it was:
You aren't a part of any groups yet! Click to create one or join any available groups below.

Let me know if that's ok, @julianguyen, and I'll get the translations and test the patch.