### PR TITLE
Issue 752

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -14,7 +14,7 @@ module Users
         (invited ? successful_invites : failed_invites) << invitee
       end
       invitation_flash_messages(successful_invites, failed_invites)
-      redirect_to new_user_invitation_path
+      redirect_to new_user_invitatigion_path
     end
 
     private

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -14,7 +14,7 @@ module Users
         (invited ? successful_invites : failed_invites) << invitee
       end
       invitation_flash_messages(successful_invites, failed_invites)
-      redirect_to new_user_invitatigion_path
+      redirect_to new_user_invitation_path
     end
 
     private

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -2,7 +2,7 @@
 
 module InvitationsHelper
   def inviter_name(resource)
-    User.where(id: resource.invited_by_id).first.presence.try(:name) ||
+    User.where(id: resource.invited_by_id).first.try(:name) ||
       'Someone'
   end
 end

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module InvitationsHelper
+  def inviter_name(resource)
+    User.where(id: resource.invited_by_id).first.presence.try(:name) ||
+      'Someone'
+  end
+end

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -2,7 +2,6 @@
 
 module InvitationsHelper
   def inviter_name(resource)
-    User.where(id: resource.invited_by_id).first.try(:name) ||
-      'Someone'
+    User.where(id: resource.invited_by_id).first.try(:name)
   end
 end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+include InvitationsHelper
+# inviter_name method from InvitationsHelper
+
+class CustomDeviseMailer < Devise::Mailer
+  protected
+
+  def subject_for(key)
+    return super unless key.to_s == 'invitation_instructions'
+
+    I18n.t(
+      'devise.mailer.invitation_instructions.subject',
+      name: inviter_name(@resource)
+    )
+  end
+end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -9,9 +9,13 @@ class CustomDeviseMailer < Devise::Mailer
   def subject_for(key)
     return super unless key.to_s == 'invitation_instructions'
 
-    I18n.t(
-      'devise.mailer.invitation_instructions.subject',
-      name: inviter_name(@resource)
-    )
+    if inviter_name(@resource)
+      I18n.t(
+        'devise.mailer.invitation_instructions.subject',
+        name: inviter_name(@resource)
+      )
+    else
+      I18n.t('devise.mailer.invitation_instructions.subject_nameless')
+    end
   end
 end

--- a/app/views/users/mailer/invitation_instructions.html.erb
+++ b/app/views/users/mailer/invitation_instructions.html.erb
@@ -1,7 +1,7 @@
 <%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
 <br>
 <br>
-<%= t("devise.mailer.invitation_instructions.someone_invited_you", name: User.where(id: @resource.invited_by_id).first.name, url: root_url) %>
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", name: inviter_name(@resource), url: root_url) %>
 <br>
 <br>
 <%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token) %>

--- a/app/views/users/mailer/invitation_instructions.text.erb
+++ b/app/views/users/mailer/invitation_instructions.text.erb
@@ -1,6 +1,6 @@
 <%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
 
-<%= t("devise.mailer.invitation_instructions.someone_invited_you", name: User.where(id: @resource.invited_by_id).first.name, url: root_url) %>
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", name: inviter_name(@resource), url: root_url) %>
 
 <%= accept_invitation_url(@resource, :invitation_token => @token) %>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -13,7 +13,7 @@ Devise.setup do |config|
   config.mailer_sender = ENV['SMTP_ADDRESS']
 
   # Configure the class responsible to send e-mails.
-  config.mailer = 'Devise::Mailer'
+  config.mailer = 'CustomDeviseMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -19,6 +19,7 @@ en:
     mailer:
       invitation_instructions:
         subject: "%{name} invited you to join if me!"
+        subject_nameless: "Someone invited you to join if me!"
         hello: "Hey %{email}!"
         someone_invited_you: "%{name} has invited you to join http://www.if-me.org, a community to share mental health experiences with your loved ones and keep track of your moods, medications, and self-care. You can accept the invite through the link below."
         accept: "Accept invitation!"

--- a/config/locales/devise_invitable.es.yml
+++ b/config/locales/devise_invitable.es.yml
@@ -19,6 +19,7 @@ es:
     mailer:
       invitation_instructions:
         subject: "¡ %{name} te ha invitado a if me!"
+        subject_nameless: "¡Te han invitado a if me!"
         hello: "Hola %{email}!"
         someone_invited_you: "%{name} te ha invitado a unirte a http://www.if-me.org, una comunidad para compartir experiencias de salud mental con tus seres queridos y mantener un registro de tus emociones, medicamento, y auto-cuidado. Puedes aceptar la invitación a través del hipervínculo de abajo."
         accept: "¡Aceptar la invitación!"

--- a/config/locales/devise_invitable.nl.yml
+++ b/config/locales/devise_invitable.nl.yml
@@ -19,6 +19,7 @@ nl:
     mailer:
       invitation_instructions:
         subject: "%{name} heeft je uitgenodigd om lid te worden van if me!"
+        subject_nameless: "Iemand heeft je uitgenodigd om lid te worden van if me!"
         hello: "Hallo %{e-mail}!"
         someone_invited_you: "%{name} heeft je uitgenodigd om lid te worden van http://www.if-me.org, een gemeenschap om ervaringsverhalen te delen over je geestelijke gezondheid met je naasten en om je stemmingen, medicatie en self-care te volgen. Je kunt de uitnodiging accepteren via onderstaande link."
         accept: "Accepteer uitnodiging!"

--- a/config/locales/devise_invitable.ptbr.yml
+++ b/config/locales/devise_invitable.ptbr.yml
@@ -19,6 +19,7 @@ ptbr:
     mailer:
       invitation_instructions:
         subject: "{%name} convidou você para participar do if me!"
+        subject_nameless: "Você acabou de ser convidado para participar do if me!"
         hello: "Olá %{email}!"
         someone_invited_you: "%{name} foi convidado para se juntar ao http://www.if-me.org, uma comunidade para compartilhar experiências sobre saúde mental com as pessoas amadas e manter o registro do seu humor, medicamentos, and cuidado pessoal. Você pode aceitar o convite através do link abaixo."
         accept: "Aceitar convite "

--- a/config/locales/devise_invitable.sv.yml
+++ b/config/locales/devise_invitable.sv.yml
@@ -19,6 +19,7 @@ sv:
     mailer:
       invitation_instructions:
         subject: "Du har blivit inbjuden att gå med i if me!"
+        subject_nameless: "Någon inbjudna dig att gå med if me!"
         hello: "Hej %{email}!"
         someone_invited_you: "%{name} har bjudit in dig att gå med i http://if-me.org, en gemenskap där du kan dela mentala förberedelser med dina nära och kära och hålla reda på ditt humör, dina mediciner och din egenvård. Du kan acceptera inbjudan via länken nedan."
         accept: "Acceptera inbjudan!"

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -8,7 +8,7 @@ describe CustomDeviseMailer do
 
   describe 'subject_for' do
     context 'if the inviting user has a name' do
-      it 'includes the inviter\s name in the subject' do
+      it 'includes the inviter\'s name in the subject' do
         User.invite!({email: recipient}, inviter)
         expect(email.subject).to eq("#{inviter.name} invited you to join if me!")
       end

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe CustomDeviseMailer do
+  let(:inviter) { create(:user2) }
+  let(:recipient) { '123@abc.com' }
+  let(:key) { 'invitation_instructions' }
+  let(:email) { Devise.mailer.deliveries.last }
+
+  describe 'subject_for' do
+    context 'if the inviting user has a name' do
+      it 'includes the inviter\s name in the subject' do
+        User.invite!({email: recipient}, inviter)
+        expect(email.subject).to eq("#{inviter.name} invited you to join if me!")
+      end
+    end
+
+    context 'if the inviting user does not have a name' do
+      it 'uses "Someone" in place of the inviter\'s name' do
+        User.invite!({email: recipient})
+        expect(email.subject).to eq("Someone invited you to join if me!")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add `subject_for` method in CustomDeviseHelper that is only called when `invitations_instructions` key is used. Method allows name of inviting user to be passed as an argument (the name previously wasn't being passed in anywhere, leading to the bug). If no name is present, selects generic invited key in translation files.
- Tests for `subject_for` method
- Create Invitations Helper & `inviter_name` method to make code more DRY.

Addresses #752 .