### PR TITLE
Improve norwegian translation

### DIFF
--- a/config/locales/devise_invitable.nb.yml
+++ b/config/locales/devise_invitable.nb.yml
@@ -18,7 +18,7 @@ nb:
         submit_button: "Sett passordet mitt"
     mailer:
       invitation_instructions:
-        subject: "%{name} inviterte deg til å bli med i hvis meg!"
+        subject: "%{name} inviterte deg til å bli med i if me!"
         subject_nameless: "Noen inviterte deg til å bli med i if me!"
         hello: "Hei %{email}!"
         someone_invited_you: "%{name} har invitert deg til å bli med i http://www.if-me.org, et felleskap for å dele mental helse opplevelser med dine kjente og holde styr på humøret ditt, medisiner, og selvpleie. Du kan akseptere invitasjonen igjennom linken nedenfor."

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -165,8 +165,8 @@ nb:
    signin: 'Del dine historier nå'
    create_account: 'Bli med i samfunnet nå'
    update_account: 'Tilpass kontoen din'
-   if: 'hvis'
-   me: 'meg'
+   if: 'if'
+   me: 'me'
   mailer:
    html:
     app_description: "%{app_name} er et samfunn som oppfordrer folk til å dele sine mental helse historier med sine kjente."


### PR DESCRIPTION
Had some time before work :). This should revert the remaining translations of the site name back to `if me`.